### PR TITLE
move logger to Reconciler struct

### DIFF
--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -55,7 +55,7 @@ type LVMClusterReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *LVMClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log = log.FromContext(ctx).WithName(ControllerName)
-	r.Log.Info("reconciling", "topolvmcluster", req)
+	r.Log.Info("reconciling", "lvmcluster", req)
 	result, err := r.reconcile(ctx, req)
 	// TODO: update status with condition describing whether reconcile succeeded
 	if err != nil {


### PR DESCRIPTION
Passing the log to all nested called functions is cumbersome.
Since we only run one Reconcile() worker at a time, we can use a
struct level var.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>