### PR TITLE
Add CSIDriver

### DIFF
--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	CSIDriver "github.com/red-hat-storage/lvm-operator/pkg/csi"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,6 +81,7 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, req ctrl.Request) 
 
 	// handle deletion
 	if !lvmCluster.DeletionTimestamp.IsZero() {
+		CSIDriver.DeleteCSIDriverInfo(ctx)
 		for _, unit := range unitList {
 			err := unit.ensureDeleted(r, ctx, *lvmCluster)
 			if err != nil {
@@ -90,6 +92,7 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, req ctrl.Request) 
 
 	// handle create/update
 	for _, unit := range unitList {
+		CSIDriver.CreateCSIDriverInfo(ctx)
 		err := unit.ensureCreated(r, ctx, *lvmCluster)
 		if err != nil {
 			return result, fmt.Errorf("failed reconciling: %s %w", unit.getName(), err)

--- a/pkg/csi/csidriver.go
+++ b/pkg/csi/csidriver.go
@@ -1,0 +1,87 @@
+package csi
+
+import (
+	"context"
+	"github.com/coreos/pkg/capnslog"
+	k8sUtils "github.com/red-hat-storage/lvm-operator/pkg/util/k8s"
+	storageV1 "k8s.io/api/storage/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	csiDriverName = "topolvm.cybozu.com"
+)
+
+var (
+	logger = capnslog.NewPackageLogger("github.com/red-hat-storage/lvm-operator", "csi")
+)
+
+// CreateCSIDriverInfo Registers CSI driver by creating a CSIDriver object
+func CreateCSIDriverInfo(ctx context.Context) error {
+	clientSet, err := k8sUtils.GetClientSet(ctx)
+	if err != nil {
+		logger.Errorf("Not possible to get a valid clientSet to add %s to CSIDrivers", csiDriverName)
+		return err
+	}
+	attachRequired := false
+	podInfoOnMount := true
+	storageCapacity := true
+
+	// Create CSIDriver object
+	csiDriver := &storageV1.CSIDriver{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: csiDriverName,
+		},
+		Spec: storageV1.CSIDriverSpec{
+			AttachRequired:       &attachRequired,
+			PodInfoOnMount:       &podInfoOnMount,
+			StorageCapacity:      &storageCapacity,
+			VolumeLifecycleModes: []storageV1.VolumeLifecycleMode{storageV1.VolumeLifecyclePersistent, storageV1.VolumeLifecycleEphemeral},
+		},
+	}
+
+	// Attach CSIDriver object
+	csiDrivers := clientSet.StorageV1().CSIDrivers()
+	driver, err := csiDrivers.Get(ctx, csiDriverName, metaV1.GetOptions{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			_, err = csiDrivers.Create(ctx, csiDriver, metaV1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+			logger.Infof("CSIDriver object created for driver %q", csiDriverName)
+
+			// For csiDriver we need to provide the resourceVersion when updating the object.
+			// From the docs (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+			// > "This value MUST be treated as opaque by clients and passed unmodified back to the server"
+			csiDriver.ObjectMeta.ResourceVersion = driver.ObjectMeta.ResourceVersion
+			_, err = csiDrivers.Update(ctx, csiDriver, metaV1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			logger.Infof("CSIDriver object updated for driver %q", csiDriverName)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DeleteCSIDriverInfo deletes CSIDriverInfo and returns the error if any
+func DeleteCSIDriverInfo(ctx context.Context) error {
+	clientSet, err := k8sUtils.GetClientSet(ctx)
+	if err != nil {
+		logger.Errorf("Not possible to get a valid clientSet to remove %s from CSIDrivers", csiDriverName)
+		return err
+	}
+
+	err = clientSet.StorageV1().CSIDrivers().Delete(ctx, csiDriverName, metaV1.DeleteOptions{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Debugf("%s CSIDriver not found; skipping deletion.", csiDriverName)
+			return nil
+		}
+	}
+	return err
+}

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1,0 +1,23 @@
+package k8s
+
+import (
+	"context"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func GetClientSet(ctx context.Context) (*kubernetes.Clientset, error) {
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		// **Not** running inside a cluster - running the operator outside the cluster.
+		// Try to read config from user config files
+		kubeConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return kubernetes.NewForConfig(kubeConfig)
+}


### PR DESCRIPTION
Not sure about several things...

- Should we use a "unit" for the CSIDriver? If the answer is yes, we will need to solve cross reference imports ( "controllers" needs "CSIDriver", and "CSIDriver" needs "controllers", we will have the same problem with other "pkgs".. (Not sure if i understand well the pattern to use the interface for units in the `lvmcluster_controller`)

- Maybe it would be useful a customized `context` with more things .. include the `clientset `can be useful for lot of things


Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>