### PR TITLE
CSI Node daemonset

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -13,6 +13,11 @@ resources:
 - topolvm_controller_service_account.yaml
 - topolvm_controller_role.yaml
 - topolvm_controller_role_bindings.yaml
+# topolvm-node rbac
+- topolvm_node_service_account.yaml
+- topolvm_node_scc.yaml
+- topolvm_node_role.yaml
+- topolvm_node_role_bindings.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,17 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create

--- a/config/rbac/topolvm_node_role.yaml
+++ b/config/rbac/topolvm_node_role.yaml
@@ -1,0 +1,45 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: topolvm-node
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+- apiGroups:
+    - topolvm.cybozu.com
+  resources:
+    - logicalvolumes
+    - logicalvolumes/status
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+    - patch
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - csidrivers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - use
+  resourceNames:
+    - privileged
+    #- topolvm-node TODO: this scc (topolvm-node) does not provide all the rights needed .. why?

--- a/config/rbac/topolvm_node_role_bindings.yaml
+++ b/config/rbac/topolvm_node_role_bindings.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: topolvm-node
+subjects:
+  - kind: ServiceAccount
+    name: topolvm-node
+    namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-node
+

--- a/config/rbac/topolvm_node_service_account.yaml
+++ b/config/rbac/topolvm_node_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: topolvm-node
+  namespace: system

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -74,6 +74,21 @@ var (
 	// CSI Provisioner requires below environment values to make use of CSIStorageCapacity
 	PodNameEnv   = "POD_NAME"
 	NameSpaceEnv = "NAMESPACE"
+
+	// topoLVM Node
+	TopolvmNodeServiceAccount       = "topolvm-node"
+	TopolvmNodeDaemonsetName        = "topolvm-node"
+	CSIKubeletRootDir               = "/var/lib/kubelet/"
+	NodeContainerName               = "topolvm-node"
+	TopolvmNodeContainerHealthzName = "healthz"
+	auxImage                        = "registry.access.redhat.com/ubi8/ubi-minimal"
+	lvmdConfigFile                  = "/etc/topolvm/lvmd.yaml"
+
+	// topoLVM Node resource requests/limits
+	TopolvmNodeMemRequest = "250Mi"
+	TopolvmNodeMemLimit   = "250Mi"
+	TopolvmNodeCPURequest = "250m"
+	TopolvmNodeCPULimit   = "250m"
 )
 
 func GetEnvOrDefault(env string) string {

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -99,6 +99,7 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 	resourceList := []resourceManager{
 		&csiDriver{},
 		&topolvmController{},
+		&topolvmNode{},
 	}
 
 	//The resource was deleted

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -1,0 +1,369 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"path/filepath"
+	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
+)
+
+const (
+	topolvmNodeName = "topolvm-node"
+)
+
+type topolvmNode struct{}
+
+func (n topolvmNode) getName() string {
+	return topolvmNodeName
+}
+
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;update;delete;get;list;watch
+
+func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
+	nodeDaemonSet := getNodeDaemonSet(lvmCluster)
+	//TODO: Use the mutate function to manage the changes in the CR (nodes, lvmd config)
+	result, err := cutil.CreateOrUpdate(ctx, r.Client, nodeDaemonSet, func() error { return nil })
+
+	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("%s reconcile failure", topolvmNodeName), "name", nodeDaemonSet.Name)
+	} else {
+		r.Log.Info(topolvmNodeName, "operation", result, "name", nodeDaemonSet.Name)
+	}
+	return err
+}
+
+// ensureDeleted should wait for the resources to be cleaned up
+func (n topolvmNode) ensureDeleted(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
+	NodeDaemonSet := &appsv1.DaemonSet{}
+	err := r.Client.Get(ctx,
+		types.NamespacedName{Name: TopolvmNodeDaemonsetName, Namespace: lvmCluster.Namespace},
+		NodeDaemonSet)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.Log.Info("topolvm node deleted", "TopolvmNode", NodeDaemonSet.Name)
+			return nil
+		}
+		r.Log.Error(err, "failed to retrieve topolvm node daemonset", "TopolvmNode", NodeDaemonSet.Name)
+		return err
+	} else {
+		// if not deleted, initiate deletion
+		if NodeDaemonSet.GetDeletionTimestamp().IsZero() {
+			if err = r.Client.Delete(ctx, NodeDaemonSet); err != nil {
+				r.Log.Error(err, "failed to delete topolvm node daemonset", "TopolvmNodeName", TopolvmNodeDaemonsetName)
+				return err
+			} else {
+				// set deletion in-progress for next reconcile to confirm deletion
+				return fmt.Errorf("topolvm csi node daemonset %s is already marked for deletion", TopolvmNodeDaemonsetName)
+			}
+		}
+	}
+
+	return nil
+}
+
+// updateStatus should optionally update the CR's status about the health of the managed resource
+// each unit will have updateStatus called individually so
+// avoid status fields like lastHeartbeatTime and have a
+// status that changes only when the operands change.
+func (n topolvmNode) updateStatus(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
+	return nil
+}
+
+func extractNodeSelectorAndTolerations(lvmCluster lvmv1alpha1.LVMCluster) (*corev1.NodeSelector, []corev1.Toleration) {
+	// TODO: use the function defined in vgmanager.go ( lest se if we can move the function to common utils location)
+	return nil, nil
+}
+
+func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster) *v1.DaemonSet {
+	hostPathDirectory := corev1.HostPathDirectory
+	hostPathDirectoryOrCreateType := corev1.HostPathDirectoryOrCreate
+	storageMedium := corev1.StorageMediumMemory
+
+	volumes := []corev1.Volume{
+		{Name: "registration-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf("%splugins_registry/", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+					Type: &hostPathDirectory}}},
+		{Name: "node-plugin-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf("%splugins/topolvm.cybozu.com/node", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+					Type: &hostPathDirectoryOrCreateType}}},
+		{Name: "csi-plugin-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf("%splugins/kubernetes.io/csi", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+					Type: &hostPathDirectoryOrCreateType}}},
+		{Name: "pod-volumes-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf("%spods/", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+					Type: &hostPathDirectoryOrCreateType}}},
+		{Name: "lvmd-config-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: filepath.Dir(lvmdConfigFile),
+					Type: &hostPathDirectory}}},
+		{Name: "lvmd-socket-dir",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: storageMedium}}},
+	}
+
+	initContainers := []corev1.Container{*getNodeInitContainer()}
+	containers := []corev1.Container{*getLvmdContainer(), *getNodeContainer(), *getCsiRegistrarContainer(), *getNodeLivenessProbeContainer()}
+
+	// Affinity and tolerations
+	nodeSelector, tolerations := extractNodeSelectorAndTolerations(*lvmCluster)
+	topolvmNodeAffinity := &corev1.Affinity{}
+	if nodeSelector != nil {
+		topolvmNodeAffinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: nodeSelector},
+		}
+	}
+	topolvmNodeTolerations := []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
+	if tolerations != nil {
+		topolvmNodeTolerations = tolerations
+	}
+
+	nodeDaemonSet := &v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TopolvmNodeDaemonsetName,
+			Namespace: lvmCluster.Namespace,
+		},
+		Spec: v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": lvmCluster.Name,
+				},
+			},
+			UpdateStrategy: v1.DaemonSetUpdateStrategy{
+				Type: v1.RollingUpdateDaemonSetStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: lvmCluster.Name,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": lvmCluster.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: TopolvmNodeServiceAccount,
+					InitContainers:     initContainers,
+					Containers:         containers,
+					Volumes:            volumes,
+					HostPID:            true,
+					Tolerations:        topolvmNodeTolerations,
+					Affinity:           topolvmNodeAffinity,
+				},
+			},
+		},
+	}
+
+	return nodeDaemonSet
+}
+
+func getNodeInitContainer() *corev1.Container {
+	command := []string{
+		"sh",
+		"-c",
+		fmt.Sprintf("until [ -f %s ]; do echo waiting for lvmd config file; sleep 5; done", lvmdConfigFile),
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "lvmd-config-dir", MountPath: "/etc/topolvm"}}
+
+	fileChecker := &corev1.Container{
+		Name:         "file-checker",
+		Image:        auxImage,
+		Command:      command,
+		VolumeMounts: volumeMounts,
+	}
+
+	return fileChecker
+}
+
+func getLvmdContainer() *corev1.Container {
+	command := []string{
+		"/lvmd",
+		fmt.Sprintf("--config=%s", lvmdConfigFile),
+		"--container=true",
+	}
+
+	resourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPULimit),
+			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPURequest),
+			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemRequest),
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "lvmd-socket-dir", MountPath: "/run/topolvm"},
+		{Name: "lvmd-config-dir", MountPath: "/etc/topolvm"}}
+
+	privilege := true
+	runUser := int64(0)
+	lvmd := &corev1.Container{
+		Name:  "lvmd",
+		Image: TopolvmCsiImage,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: &privilege,
+			RunAsUser:  &runUser,
+		},
+		Command:      command,
+		Resources:    resourceRequirements,
+		VolumeMounts: volumeMounts,
+	}
+	return lvmd
+}
+
+func getNodeContainer() *corev1.Container {
+	privileged := true
+	runAsUser := int64(0)
+
+	command := []string{
+		"/topolvm-node",
+		"--lvmd-socket=/run/lvmd/lvmd.sock",
+	}
+
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPULimit),
+			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPURequest),
+			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemRequest),
+		},
+	}
+
+	mountPropagationMode := corev1.MountPropagationBidirectional
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "node-plugin-dir", MountPath: "/run/topolvm"},
+		{Name: "lvmd-socket-dir", MountPath: "/run/lvmd"},
+		{Name: "pod-volumes-dir",
+			MountPath:        fmt.Sprintf("%spods", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+			MountPropagation: &mountPropagationMode},
+		{Name: "csi-plugin-dir",
+			MountPath:        fmt.Sprintf("%splugins/kubernetes.io/csi", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+			MountPropagation: &mountPropagationMode},
+	}
+
+	env := []corev1.EnvVar{
+		{Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName"}}}}
+
+	node := &corev1.Container{
+		Name:    NodeContainerName,
+		Image:   TopolvmCsiImage,
+		Command: command,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: &privileged,
+			RunAsUser:  &runAsUser,
+		},
+		Ports: []corev1.ContainerPort{{Name: TopolvmNodeContainerHealthzName,
+			ContainerPort: 9808,
+			Protocol:      corev1.ProtocolTCP}},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/healthz",
+					Port: intstr.FromString(TopolvmNodeContainerHealthzName)}},
+			FailureThreshold:    3,
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      3,
+			PeriodSeconds:       60},
+		Resources:    requirements,
+		Env:          env,
+		VolumeMounts: volumeMounts,
+	}
+	return node
+}
+
+func getCsiRegistrarContainer() *corev1.Container {
+	command := []string{
+		"/csi-node-driver-registrar",
+		"--csi-address=/run/topolvm/csi-topolvm.sock",
+		fmt.Sprintf("--kubelet-registration-path=%splugins/topolvm.cybozu.com/node/csi-topolvm.sock", getAbsoluteKubeletPath(CSIKubeletRootDir)),
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "node-plugin-dir", MountPath: "/run/topolvm"},
+		{Name: "registration-dir", MountPath: "/registration"},
+	}
+
+	preStopCmd := []string{
+		"/bin/sh",
+		"-c",
+		"rm -rf /registration/topolvm.cybozu.com /registration/topolvm.cybozu.com-reg.sock",
+	}
+
+	csiRegistrar := &corev1.Container{
+		Name:         "csi-registrar",
+		Image:        CsiRegistrarImage,
+		Command:      command,
+		Lifecycle:    &corev1.Lifecycle{PreStop: &corev1.Handler{Exec: &corev1.ExecAction{Command: preStopCmd}}},
+		VolumeMounts: volumeMounts,
+	}
+	return csiRegistrar
+}
+
+func getNodeLivenessProbeContainer() *corev1.Container {
+	command := []string{
+		"/livenessprobe",
+		"--csi-address=/run/topolvm/csi-topolvm.sock",
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "node-plugin-dir", MountPath: "/run/topolvm"},
+	}
+
+	liveness := &corev1.Container{
+		Name:         "liveness-probe",
+		Image:        CsiLivenessProbeImage,
+		Command:      command,
+		VolumeMounts: volumeMounts,
+	}
+	return liveness
+}
+
+func getAbsoluteKubeletPath(name string) string {
+	if strings.HasSuffix(name, "/") {
+		return name
+	} else {
+		return name + "/"
+	}
+}


### PR DESCRIPTION
I need to go through unit tests but I think it is good to have a first version of the node daemonset to discuss changes and improvements.

I have **lot of doubts about to use a configmap for storing the lvmd configuration**. It can work for SNO deployments, but we are going to have problems with more that 1 node clusters, because the configmap cannot be different for each node using a Daemonset. 
The only way I see to do that is to use a init container to read a configmap (one per node) and generate a file to be used when lvmd starts. Thoughts?

Update management: 
I only can see two changes to manage:
1. Change of nodes : Now, we do not have the node selector in the CRD. We will need to address this part when we will introduce tyhe node selector
2. Change of lvmd configuration: a new Sc or new VGs in the node. Probably to address when we have a first version wroking for SNO with the happy path.

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>