### PR TITLE
controller: sets namespace to openshift-storage

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: lvm-operator-system
+namespace: openshift-storage
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
Changed the default operator namespace to openshift-storage.

Signed-off-by: N Balachandran <nibalach@redhat.com>