### PR TITLE
controller: operator now watches own namespace

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,5 +52,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This introduces the WATCH_NAMESPACE env which is set the the operator's
own namespace. This allows the operator to be configured to watch only its
own namespace.

Signed-off-by: N Balachandran <nibalach@redhat.com>