### PR TITLE
manifests: adds env vars to config map

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,8 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
+- envs:
+  - manager.env
   files:
   - controller_manager_config.yaml
+  name: lvm-operator-manager-config

--- a/config/manager/manager.env
+++ b/config/manager/manager.env
@@ -1,0 +1,6 @@
+OPERATOR_NAMESPACE=openshift-storage
+TOPOLVM_CSI_IMAGE=quay.io/topolvm/topolvm:0.10.3
+CSI_REGISTRAR_IMAGE=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+CSI_PROVISIONER_IMAGE=k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+CSI_LIVENESSPROBE_IMAGE=k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
+CSI_RESIZER_IMAGE=k8s.gcr.io/sig-storage/csi-resizer:v1.3.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,5 +57,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: lvm-operator-manager-config
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Adds env vars to the operator config ConfigMap and expose them as container environment variables.

Signed-off-by: N Balachandran <nibalach@redhat.com>