### PR TITLE
feat: add support for default device class in the CR

### DIFF
--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -37,6 +37,10 @@ type DeviceClass struct {
 	// Name of the class, the VG and possibly the storageclass.
 	Name string `json:"name,omitempty"`
 
+	// Default flag to indicate that this device-class is used by default
+	// +optional
+	Default bool `json:"default,omitempty"`
+
 	// DeviceSelector is a set of rules that should match for a device to be included in this TopoLVMCluster
 	// +optional
 	DeviceSelector *DeviceSelector `json:"deviceSelector,omitempty"`

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -41,6 +41,10 @@ spec:
                   to volumegroups that are used for creating lvm based PVs
                 items:
                   properties:
+                    default:
+                      description: Default flag to indicate that this device-class
+                        is used by default
+                      type: boolean
                     deviceSelector:
                       description: DeviceSelector is a set of rules that should match
                         for a device to be included in this TopoLVMCluster

--- a/config/samples/lvm_v1alpha1_lvmcluster.yaml
+++ b/config/samples/lvm_v1alpha1_lvmcluster.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   deviceClasses:
   - name: vg1
+    default: true


### PR DESCRIPTION
This PR provides support to add default device class in the lvmCluster CR by adding a new optional field called `Default`. 

The deviceClasses need at least one device class with `default: true` else lvmd will show below error.
```
$ oc logs --follow topolvm-node-htbvs     -n lvm-operator-system lvmd
should have only one default device-class
2021-12-22T03:00:32.542649Z topolvm-node-htbvs lvmd info: "configuration file loaded: " device_classes="[0xc00068ec80]" file_name="/etc/topolvm/lvmd.yaml" socket_name="/run/topolvm/lvmd.sock"
Error: should have only one default device-class
```

Signed-off-by: Santosh Pillai <sapillai@redhat.com>