### PR TITLE
fix: use default socket paths for CSI and LVMd

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -18,8 +18,6 @@ package controllers
 
 import (
 	"os"
-
-	"github.com/topolvm/topolvm"
 )
 
 var (
@@ -96,10 +94,9 @@ var (
 	TopolvmNodeCPURequest = "250m"
 	TopolvmNodeCPULimit   = "250m"
 
-	// Defaults from topolvm project
-	TopolvmCSISockPath = topolvm.DefaultCSISocket
-	LVMdSocketPath     = topolvm.DefaultLVMdSocket
-	DeviceClassKey     = topolvm.DeviceClassKey
+	DefaultCSISocket  = "/run/topolvm/csi-topolvm.sock"
+	DefaultLVMdSocket = "/run/lvmd/lvmd.sock"
+	DeviceClassKey    = "topolvm.cybozu.com/device-class"
 
 	// default fstype for topolvm storage classes
 	TopolvmFilesystemType = "xfs"

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -200,7 +200,7 @@ func getControllerContainer() *corev1.Container {
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "socket-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "socket-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 		{Name: "certs", MountPath: "/certs"},
 	}
 
@@ -248,7 +248,7 @@ func getCsiProvisionerContainer() *corev1.Container {
 
 	// csi provisioner container
 	command := []string{"/csi-provisioner",
-		fmt.Sprintf("--csi-address=%s", TopolvmCSISockPath),
+		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 		"--enable-capacity",
 		"--capacity-ownerref-level=2",
 		"--capacity-poll-interval=30s",
@@ -267,7 +267,7 @@ func getCsiProvisionerContainer() *corev1.Container {
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "socket-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "socket-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 	}
 
 	env := []corev1.EnvVar{
@@ -305,11 +305,11 @@ func getCsiResizerContainer() *corev1.Container {
 	// csi resizer container
 	command := []string{
 		"/csi-resizer",
-		fmt.Sprintf("--csi-address=%s", TopolvmCSISockPath),
+		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "socket-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "socket-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 	}
 
 	csiResizer := &corev1.Container{
@@ -326,11 +326,11 @@ func getLivenessProbeContainer() *corev1.Container {
 	// csi liveness probe container
 	command := []string{
 		"/livenessprobe",
-		fmt.Sprintf("--csi-address=%s", TopolvmCSISockPath),
+		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "socket-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "socket-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 	}
 
 	livenessProbe := &corev1.Container{

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -250,7 +250,7 @@ func getLvmdContainer() *corev1.Container {
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "lvmd-socket-dir", MountPath: filepath.Dir(LVMdSocketPath)},
+		{Name: "lvmd-socket-dir", MountPath: filepath.Dir(DefaultLVMdSocket)},
 		{Name: "lvmd-config-dir", MountPath: filepath.Dir(LvmdConfigFile)},
 	}
 
@@ -276,7 +276,7 @@ func getNodeContainer() *corev1.Container {
 
 	command := []string{
 		"/topolvm-node",
-		fmt.Sprintf("--lvmd-socket=%s", LVMdSocketPath),
+		fmt.Sprintf("--lvmd-socket=%s", DefaultLVMdSocket),
 	}
 
 	requirements := corev1.ResourceRequirements{
@@ -293,8 +293,8 @@ func getNodeContainer() *corev1.Container {
 	mountPropagationMode := corev1.MountPropagationBidirectional
 
 	volumeMounts := []corev1.VolumeMount{
-		// parent dir for both csi and lvm sock file is same
-		{Name: "node-plugin-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "node-plugin-dir", MountPath: filepath.Dir(DefaultCSISocket)},
+		{Name: "lvmd-socket-dir", MountPath: filepath.Dir(DefaultLVMdSocket)},
 		{Name: "pod-volumes-dir",
 			MountPath:        fmt.Sprintf("%spods", getAbsoluteKubeletPath(CSIKubeletRootDir)),
 			MountPropagation: &mountPropagationMode},
@@ -338,12 +338,12 @@ func getNodeContainer() *corev1.Container {
 func getCsiRegistrarContainer() *corev1.Container {
 	command := []string{
 		"/csi-node-driver-registrar",
-		fmt.Sprintf("--csi-address=%s", TopolvmCSISockPath),
+		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 		fmt.Sprintf("--kubelet-registration-path=%splugins/topolvm.cybozu.com/node/csi-topolvm.sock", getAbsoluteKubeletPath(CSIKubeletRootDir)),
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "node-plugin-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "node-plugin-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 		{Name: "registration-dir", MountPath: "/registration"},
 	}
 
@@ -366,11 +366,11 @@ func getCsiRegistrarContainer() *corev1.Container {
 func getNodeLivenessProbeContainer() *corev1.Container {
 	command := []string{
 		"/livenessprobe",
-		fmt.Sprintf("--csi-address=%s", TopolvmCSISockPath),
+		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		{Name: "node-plugin-dir", MountPath: filepath.Dir(TopolvmCSISockPath)},
+		{Name: "node-plugin-dir", MountPath: filepath.Dir(DefaultCSISocket)},
 	}
 
 	liveness := &corev1.Container{

--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -91,7 +91,7 @@ func (r *VGReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 
 	// load lvmd config
 	lvmdConfig := &lvmdCMD.Config{
-		SocketName: controllers.LVMdSocketPath,
+		SocketName: controllers.DefaultLVMdSocket,
 	}
 
 	cfgBytes, err := os.ReadFile(controllers.LvmdConfigFile)


### PR DESCRIPTION
- In #39 values for socket paths are pulled from topolvm project
- However the directories for CSI and LVMd dock paths is same
- In #39 one of the dir is removed erroneously and that is fixed by this
  PR to use our own values not to have any clashes.

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>