### PR TITLE
fix: create all resources in the operator namespace

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -169,10 +169,10 @@ spec:
                 command:
                 - /manager
                 env:
-                - name: WATCH_NAMESPACE
+                - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                      fieldPath: metadata.namespace
                 envFrom:
                 - configMapRef:
                     name: lvm-operator-manager-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
             cpu: 100m
             memory: 20Mi
         env:
-        - name: WATCH_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -56,6 +56,7 @@ type LVMClusterReconciler struct {
 	Log            logr.Logger
 	ClusterType    ClusterType
 	SecurityClient secv1client.SecurityV1Interface
+	Namespace      string
 }
 
 //+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmclusters,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -45,7 +45,7 @@ func (c openshiftSccs) ensureCreated(r *LVMClusterReconciler, ctx context.Contex
 		r.Log.Info("not creating SCCs as this is not an Openshift cluster")
 		return nil
 	}
-	sccs := getAllSCCs(lvmCluster.Namespace)
+	sccs := getAllSCCs(r.Namespace)
 	for _, scc := range sccs {
 		_, err := r.SecurityClient.SecurityContextConstraints().Get(ctx, scc.Name, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
@@ -69,7 +69,7 @@ func (c openshiftSccs) ensureCreated(r *LVMClusterReconciler, ctx context.Contex
 func (c openshiftSccs) ensureDeleted(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
 	if IsOpenshift(r) {
 		var err error
-		sccs := getAllSCCs(lvmCluster.Namespace)
+		sccs := getAllSCCs(r.Namespace)
 		for _, scc := range sccs {
 			err = r.SecurityClient.SecurityContextConstraints().Delete(ctx, scc.Name, metav1.DeleteOptions{})
 			if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -100,6 +100,7 @@ var _ = BeforeSuite(func() {
 		Client:         k8sManager.GetClient(),
 		Scheme:         k8sManager.GetScheme(),
 		SecurityClient: secv1client.NewForConfigOrDie(k8sManager.GetConfig()),
+		Namespace:      testLvmClusterNamespace,
 		Log:            ctrl.Log.WithName("controllers").WithName("LvmCluster"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -34,7 +34,7 @@ func (c topolvmController) getName() string {
 func (c topolvmController) ensureCreated(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
 
 	// get the desired state of topolvm controller deployment
-	desiredDeployment := getControllerDeployment(lvmCluster)
+	desiredDeployment := getControllerDeployment(lvmCluster, r.Namespace)
 	existingDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      desiredDeployment.Name,
@@ -57,7 +57,7 @@ func (c topolvmController) ensureCreated(r *LVMClusterReconciler, ctx context.Co
 
 func (c topolvmController) ensureDeleted(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
 	existingDeployment := &appsv1.Deployment{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: TopolvmControllerDeploymentName, Namespace: lvmCluster.Namespace}, existingDeployment)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: TopolvmControllerDeploymentName, Namespace: r.Namespace}, existingDeployment)
 
 	if err != nil {
 		// already deleted in previous reconcile
@@ -105,7 +105,7 @@ func (c topolvmController) setTopolvmControllerDesiredState(existing, desired *a
 	return nil
 }
 
-func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster) *appsv1.Deployment {
+func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster, namespace string) *appsv1.Deployment {
 
 	// Topolvm CSI Controller Deployment
 	var replicas int32 = 1
@@ -129,7 +129,7 @@ func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster) *appsv1.Deploym
 	controllerDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TopolvmControllerDeploymentName,
-			Namespace: lvmCluster.Namespace,
+			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -141,7 +141,7 @@ func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster) *appsv1.Deploym
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      TopolvmControllerDeploymentName,
-					Namespace: lvmCluster.Namespace,
+					Namespace: namespace,
 					Labels: map[string]string{
 						AppAttr: TopolvmControllerDeploymentName,
 					},

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -49,7 +49,7 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 	unitLogger := r.Log.WithValues("topolvmNode", n.getName())
 
 	// get desired daemonSet spec
-	dsTemplate := getNodeDaemonSet(lvmCluster)
+	dsTemplate := getNodeDaemonSet(lvmCluster, r.Namespace)
 	// create desired daemonSet or update mutable fields on existing one
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -93,7 +93,7 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 func (n topolvmNode) ensureDeleted(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
 	NodeDaemonSet := &appsv1.DaemonSet{}
 	err := r.Client.Get(ctx,
-		types.NamespacedName{Name: TopolvmNodeDaemonsetName, Namespace: lvmCluster.Namespace},
+		types.NamespacedName{Name: TopolvmNodeDaemonsetName, Namespace: r.Namespace},
 		NodeDaemonSet)
 
 	if err != nil {
@@ -127,7 +127,7 @@ func (n topolvmNode) updateStatus(r *LVMClusterReconciler, ctx context.Context, 
 	return nil
 }
 
-func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster) *appsv1.DaemonSet {
+func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster, namespace string) *appsv1.DaemonSet {
 	hostPathDirectory := corev1.HostPathDirectory
 	hostPathDirectoryOrCreateType := corev1.HostPathDirectoryOrCreate
 	storageMedium := corev1.StorageMediumMemory
@@ -179,7 +179,7 @@ func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster) *appsv1.DaemonSet {
 	nodeDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TopolvmNodeDaemonsetName,
-			Namespace: lvmCluster.Namespace,
+			Namespace: namespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -43,7 +43,7 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	unitLogger := r.Log.WithValues("resourceManager", v.getName())
 
 	// get desired daemonset spec
-	dsTemplate := newVGManagerDaemonset(*lvmCluster)
+	dsTemplate := newVGManagerDaemonset(*lvmCluster, r.Namespace)
 
 	// controller reference
 	err := ctrl.SetControllerReference(lvmCluster, &dsTemplate, r.Scheme)

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -112,7 +112,7 @@ var (
 )
 
 // newVGManagerDaemonset returns the desired vgmanager daemonset for a given LVMCluster
-func newVGManagerDaemonset(lvmCluster lvmv1alpha1.LVMCluster) appsv1.DaemonSet {
+func newVGManagerDaemonset(lvmCluster lvmv1alpha1.LVMCluster, namespace string) appsv1.DaemonSet {
 	// aggregate nodeSelector and tolerations from all deviceClasses
 	nodeSelector, tolerations := extractNodeSelectorAndTolerations(lvmCluster)
 	volumes := []corev1.Volume{LVMDConfVol, DevHostDirVol, UDevHostDirVol, SysHostDirVol}
@@ -163,7 +163,7 @@ func newVGManagerDaemonset(lvmCluster lvmv1alpha1.LVMCluster) appsv1.DaemonSet {
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      VGManagerUnit,
-			Namespace: lvmCluster.Namespace,
+			Namespace: namespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/controllers/vgmanager_test.go
+++ b/controllers/vgmanager_test.go
@@ -36,9 +36,10 @@ func newFakeLVMClusterReconciler(t *testing.T, objs ...client.Object) *LVMCluste
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 	return &LVMClusterReconciler{
-		Client: client,
-		Scheme: scheme,
-		Log:    logf.Log.WithName("LVMCLusterTest"),
+		Client:    client,
+		Scheme:    scheme,
+		Log:       logf.Log.WithName("LVMCLusterTest"),
+		Namespace: "default",
 	}
 }
 


### PR DESCRIPTION
This fix creates all resources in the operator namespace instead of the LVMCluster namespace. This is required if, in future, the operator will be extended to watch all namespaces.