### PR TITLE
fix: fixes logger panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 			"Exiting")
 		os.Exit(1)
 	}
-	setupLog.Info("Watching namespace ", operatorNamespace)
+	setupLog.Info("Watching namespace", "Namespace", operatorNamespace)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
Fixed the issue where an incorrect number of arguments caused
the logger to panic.

Signed-off-by: N Balachandran <nibalach@redhat.com>