### PR TITLE
refactor: Update cert expiry to 10 years

### DIFF
--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -164,7 +164,7 @@ func getInitContainer() *corev1.Container {
 	command := []string{
 		"sh",
 		"-c",
-		"openssl req -nodes -x509 -newkey rsa:4096 -subj '/DC=self_signed_certificate' -keyout /certs/tls.key -out /certs/tls.crt -days 365",
+		"openssl req -nodes -x509 -newkey rsa:4096 -subj '/DC=self_signed_certificate' -keyout /certs/tls.key -out /certs/tls.crt -days 3650",
 	}
 
 	volumeMounts := []corev1.VolumeMount{


### PR DESCRIPTION
Current cert expiry is 356 days. This PR updates the expiry to 3560
days.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>