### PR TITLE
fix: add label for namespace for metrics collection

### DIFF
--- a/olm-deploy/openshift-storage-namespace.yaml
+++ b/olm-deploy/openshift-storage-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
- Presence of this label on a namespace indicates monitoring machinery to
  scrape metrics using servicemonitors

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>