### PR TITLE
fix: sets bundle namespace to openshift-storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ endef
 .PHONY: bundle
 bundle: update-mgr-env manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
+	cd config/default && $(KUSTOMIZE) edit set namespace $(OPERATOR_NAMESPACE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/default && $(KUSTOMIZE) edit set image rbac-proxy=$(RBAC_PROXY_IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --package $(BUNDLE_PACKAGE) --version $(VERSION) $(BUNDLE_METADATA_OPTS)


### PR DESCRIPTION
This sets the bundle manifests namespace to openshift-storage by
default.

Signed-off-by: N Balachandran <nibalach@redhat.com>