### PR TITLE
fix: remove the development log flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Sets the zap Development option to false.

Signed-off-by: N Balachandran <nibalach@redhat.com>