### PR TITLE
fix: fixes csv with different bundle pkg name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,14 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+.PHONY: rename-csv
+rename-csv: 
+	cp config/manifests/bases/clusterserviceversion.yaml.in config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml
+	sed 's/@BUNDLE_PACKAGE@/$(BUNDLE_PACKAGE)/g' --in-place config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml 
 
 .PHONY: bundle
-bundle: update-mgr-env manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(OPERATOR_SDK) generate kustomize manifests -q
+bundle: update-mgr-env manifests kustomize operator-sdk rename-csv ## Generate bundle manifests and metadata, then validate generated files.
+#	$(OPERATOR_SDK) generate kustomize manifests --package $(BUNDLE_PACKAGE) -q
 	cd config/default && $(KUSTOMIZE) edit set namespace $(OPERATOR_NAMESPACE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/default && $(KUSTOMIZE) edit set image rbac-proxy=$(RBAC_PROXY_IMG)

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: lvm-operator.v0.0.0
+  name: @BUNDLE_PACKAGE@.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/lvm-operator.clusterserviceversion.yaml
+#- bases/odf-lvm-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
When a different package name is used for the bundle,
operator-sdk generates a new CSV with the default InstallModes.
This fails to install the operator into the openshift-storage namespace
because of the mismatch with the operatorgroup.

Signed-off-by: N Balachandran <nibalach@redhat.com>