### PR TITLE
fix: sets env vars in the manager deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,12 @@ export MANAGER_ENV_VARS
 
 update-mgr-env: ## Feed env variables to the manager configmap
 	@echo "$$MANAGER_ENV_VARS" > config/manager/manager.env
+	cp config/default/manager_custom_env.yaml.in config/default/manager_custom_env.yaml
+	sed 's|TOPOLVM_CSI_IMAGE_VAL|$(TOPOLVM_CSI_IMAGE)|g' --in-place config/default/manager_custom_env.yaml
+	sed 's|CSI_LIVENESSPROBE_IMAGE_VAL|$(CSI_LIVENESSPROBE_IMAGE)|g' --in-place config/default/manager_custom_env.yaml
+	sed 's|CSI_PROVISIONER_IMAGE_VAL|$(CSI_PROVISIONER_IMAGE)|g' --in-place config/default/manager_custom_env.yaml
+	sed 's|CSI_RESIZER_IMAGE_VAL|$(CSI_RESIZER_IMAGE)|g' --in-place config/default/manager_custom_env.yaml
+	sed 's|CSI_REGISTRAR_IMAGE_VAL|$(CSI_REGISTRAR_IMAGE)|g' --in-place config/default/manager_custom_env.yaml
 
 
 ##@ Build
@@ -155,7 +161,7 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: update-mgr-env manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	cd config/default && $(KUSTOMIZE) edit set image rbac-proxy=$(RBAC_PROXY_IMG)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: lvm-operator-system
+namespace: openshift-storage
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -23,6 +23,7 @@ namespace: lvm-operator-system
 # endpoint w/o any authn/z, please comment the following line.
 patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
+- manager_custom_env.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_custom_env.yaml.in
+++ b/config/default/manager_custom_env.yaml.in
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: TOPOLVM_CSI_IMAGE
+          value: TOPOLVM_CSI_IMAGE_VAL
+        - name: CSI_LIVENESSPROBE_IMAGE
+          value: CSI_LIVENESSPROBE_IMAGE_VAL
+        - name: CSI_PROVISIONER_IMAGE
+          value: CSI_PROVISIONER_IMAGE_VAL
+        - name: CSI_REGISTRAR_IMAGE
+          value: CSI_REGISTRAR_IMAGE_VAL
+        - name: CSI_RESIZER_IMAGE
+          value: CSI_RESIZER_IMAGE_VAL

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,10 +3,3 @@ resources:
 
 generatorOptions:
   disableNameSuffixHash: true
-
-configMapGenerator:
-- envs:
-  - manager.env
-  files:
-  - controller_manager_config.yaml
-  name: lvm-operator-manager-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,9 +64,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        envFrom:
-        - configMapRef:
-            name: lvm-operator-manager-config
       - command:
         - /metricsexporter
         image: controller:latest


### PR DESCRIPTION
Env vars for the manager deployment were earlier set using a configmap.
That does not work well with the downstream build mirroring pipeline.
This fix sets the env vars directly in the manager deployment spec.

Signed-off-by: N Balachandran <nibalach@redhat.com>