### PR TITLE
fix: do not override entrypoint for sidecar images

### DIFF
--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -248,7 +248,7 @@ func getControllerContainer() *corev1.Container {
 func getCsiProvisionerContainer() *corev1.Container {
 
 	// csi provisioner container
-	command := []string{"/csi-provisioner",
+	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 		"--enable-capacity",
 		"--capacity-ownerref-level=2",
@@ -293,7 +293,7 @@ func getCsiProvisionerContainer() *corev1.Container {
 	csiProvisioner := &corev1.Container{
 		Name:         CsiProvisionerContainerName,
 		Image:        CsiProvisionerImage,
-		Command:      command,
+		Args:         args,
 		Resources:    resourceRequirements,
 		VolumeMounts: volumeMounts,
 		Env:          env,
@@ -304,8 +304,7 @@ func getCsiProvisionerContainer() *corev1.Container {
 func getCsiResizerContainer() *corev1.Container {
 
 	// csi resizer container
-	command := []string{
-		"/csi-resizer",
+	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
@@ -316,7 +315,7 @@ func getCsiResizerContainer() *corev1.Container {
 	csiResizer := &corev1.Container{
 		Name:         CsiResizerContainerName,
 		Image:        CsiResizerImage,
-		Command:      command,
+		Args:         args,
 		VolumeMounts: volumeMounts,
 	}
 	return csiResizer
@@ -325,8 +324,7 @@ func getCsiResizerContainer() *corev1.Container {
 func getLivenessProbeContainer() *corev1.Container {
 
 	// csi liveness probe container
-	command := []string{
-		"/livenessprobe",
+	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
@@ -337,7 +335,7 @@ func getLivenessProbeContainer() *corev1.Container {
 	livenessProbe := &corev1.Container{
 		Name:         CsiLivenessProbeContainerName,
 		Image:        CsiLivenessProbeImage,
-		Command:      command,
+		Args:         args,
 		VolumeMounts: volumeMounts,
 	}
 	return livenessProbe

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -336,8 +336,7 @@ func getNodeContainer() *corev1.Container {
 }
 
 func getCsiRegistrarContainer() *corev1.Container {
-	command := []string{
-		"/csi-node-driver-registrar",
+	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 		fmt.Sprintf("--kubelet-registration-path=%splugins/topolvm.cybozu.com/node/csi-topolvm.sock", getAbsoluteKubeletPath(CSIKubeletRootDir)),
 	}
@@ -356,7 +355,7 @@ func getCsiRegistrarContainer() *corev1.Container {
 	csiRegistrar := &corev1.Container{
 		Name:         "csi-registrar",
 		Image:        CsiRegistrarImage,
-		Command:      command,
+		Args:         args,
 		Lifecycle:    &corev1.Lifecycle{PreStop: &corev1.Handler{Exec: &corev1.ExecAction{Command: preStopCmd}}},
 		VolumeMounts: volumeMounts,
 	}
@@ -364,8 +363,7 @@ func getCsiRegistrarContainer() *corev1.Container {
 }
 
 func getNodeLivenessProbeContainer() *corev1.Container {
-	command := []string{
-		"/livenessprobe",
+	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
 
@@ -376,7 +374,7 @@ func getNodeLivenessProbeContainer() *corev1.Container {
 	liveness := &corev1.Container{
 		Name:         "liveness-probe",
 		Image:        CsiLivenessProbeImage,
-		Command:      command,
+		Args:         args,
 		VolumeMounts: volumeMounts,
 	}
 	return liveness


### PR DESCRIPTION
- overriding entrypoint for sidecars result in incorrect binary paths
  while different images are used
- removing explicit command set while deploying containers to use
  default entrypoints

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>