### PR TITLE
fix: use operator image for init containers

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -23,6 +23,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o metricsexporter cmd/met
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
 FROM centos:8
+
+# Install required utilities
+RUN dnf install -y openssl && dnf clean all
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/vgmanager .

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -86,7 +86,6 @@ var (
 	CSIKubeletRootDir               = "/var/lib/kubelet/"
 	NodeContainerName               = "topolvm-node"
 	TopolvmNodeContainerHealthzName = "healthz"
-	auxImage                        = "registry.access.redhat.com/ubi8/ubi-minimal"
 	LvmdConfigFile                  = "/etc/topolvm/lvmd.yaml"
 
 	// topoLVM Node resource requests/limits

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -61,6 +61,7 @@ const (
 	testLvmClusterName      = "test-lvmcluster"
 	testLvmClusterNamespace = "openshift-storage"
 	testDeviceClassName     = "test"
+	testImageName           = "test"
 )
 
 var _ = BeforeSuite(func() {
@@ -103,6 +104,7 @@ var _ = BeforeSuite(func() {
 		SecurityClient: secv1client.NewForConfigOrDie(k8sManager.GetConfig()),
 		Namespace:      testLvmClusterNamespace,
 		Log:            ctrl.Log.WithName("controllers").WithName("LvmCluster"),
+		ImageName:      testImageName,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -43,13 +43,10 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	unitLogger := r.Log.WithValues("resourceManager", v.getName())
 
 	// get desired daemonset spec
-	dsTemplate, err := newVGManagerDaemonset(r, ctx, lvmCluster)
-	if err != nil {
-		return fmt.Errorf("failed to get new VGManager Daemonset due to %v", err)
-	}
+	dsTemplate := newVGManagerDaemonset(lvmCluster, r.Namespace, r.ImageName)
 
 	// controller reference
-	err = ctrl.SetControllerReference(lvmCluster, &dsTemplate, r.Scheme)
+	err := ctrl.SetControllerReference(lvmCluster, &dsTemplate, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to set controller reference on vgManager daemonset %q. %v", dsTemplate.Name, err)
 	}

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -18,14 +18,12 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -212,27 +210,4 @@ func newVGManagerDaemonset(r *LVMClusterReconciler, ctx context.Context, lvmClus
 	// set nodeSelector
 	setDaemonsetNodeSelector(nodeSelector, &ds)
 	return ds, nil
-}
-
-func getRunningPodImage(r *LVMClusterReconciler, ctx context.Context) (string, error) {
-
-	// 'POD_NAME' and 'POD_NAMESPACE' are set in env of lvm-operator when running as a container
-	podName := os.Getenv("POD_NAME")
-	if podName == "" {
-		return "", fmt.Errorf("failed to get pod name env variable")
-	}
-
-	pod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: r.Namespace}, pod); err != nil {
-		return "", fmt.Errorf("failed to get pod %s in namespace %s", podName, r.Namespace)
-	}
-
-	for _, c := range pod.Spec.Containers {
-		if c.Name == LVMOperatorContainerName {
-			return c.Image, nil
-		}
-	}
-
-	return "", fmt.Errorf("failed to get container image for %s in pod %s", LVMOperatorContainerName, podName)
-
 }


### PR DESCRIPTION
- move function to get running pod image into common controller utils
- use operator image from running pod for init containers in topolvm
  controller and topolvm node

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>