### PR TITLE
Adding an alert mechanism into lvm-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,9 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: rename-csv
-rename-csv: 
+rename-csv:
 	cp config/manifests/bases/clusterserviceversion.yaml.in config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml
-	sed 's/@BUNDLE_PACKAGE@/$(BUNDLE_PACKAGE)/g' --in-place config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml 
+	sed 's/@BUNDLE_PACKAGE@/$(BUNDLE_PACKAGE)/g' --in-place config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml
 
 .PHONY: bundle
 bundle: update-mgr-env manifests kustomize operator-sdk rename-csv ## Generate bundle manifests and metadata, then validate generated files.

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - monitor.yaml
+- prometheus_rules.yaml

--- a/config/prometheus/prometheus_rules.yaml
+++ b/config/prometheus/prometheus_rules.yaml
@@ -1,0 +1,26 @@
+"apiVersion": "monitoring.coreos.com/v1"
+"kind": "PrometheusRule"
+"metadata":
+  "name": "prometheus-lvmo-rules"
+"spec":
+  "groups":
+  - "name": "vg-alert.rules"
+    "rules":
+    - "alert": "VolumeGroupUsageAtThresholdNearFull"
+      "annotations":
+        "description": "VolumeGroup is nearing full. Data deletion or VolumeGroup expansion is required."
+        "message": "VolumeGroup {{ $labels.device_class }} utilization has crossed 75 % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup."
+      "expr": |
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.75 and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= 0.85
+      "for": "5m"
+      "labels":
+        "severity": "warning"
+    - "alert": "VolumeGroupUsageAtThresholdCritical"
+      "annotations":
+        "description": "VolumeGroup is critically full. Data deletion or VolumeGroup expansion is required."
+        "message": "VolumeGroup {{ $labels.device_class }} utilization has crossed 85 % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup immediately."
+      "expr": |
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.85
+      "for": "5m"
+      "labels":
+        "severity": "critical"

--- a/monitoring/alerts/alerts.jsonnet
+++ b/monitoring/alerts/alerts.jsonnet
@@ -1,0 +1,2 @@
+std.manifestYamlDoc((import '../mixin.libsonnet').prometheus)
+

--- a/monitoring/alerts/vgalerts.libsonnet
+++ b/monitoring/alerts/vgalerts.libsonnet
@@ -1,0 +1,39 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'vg-alert.rules',
+        rules: [
+          {
+            alert: 'VolumeGroupUsageAtThresholdNearFull',
+            expr: |||
+              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdNearFull)0.2f and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= %(vgUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.volumegroupUsageThresholdAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'VolumeGroup is nearing full. Data deletion or VolumeGroup expansion is required.',
+              message: 'VolumeGroup {{ $labels.device_class }} utilization has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the VolumeGroup.' % ($._config.vgUsageThresholdNearFull*100),
+            },
+          },
+          {
+            alert: 'VolumeGroupUsageAtThresholdCritical',
+            expr: |||
+              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.volumegroupUsageThresholdAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              description: 'VolumeGroup is critically full. Data deletion or VolumeGroup expansion is required.',
+              message: 'VolumeGroup {{ $labels.device_class }} utilization has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the VolumeGroup immediately.' % ($._config.vgUsageThresholdCritical * 100),
+            },
+          },
+	],
+      },
+    ],
+  },
+}

--- a/monitoring/config.libsonnet
+++ b/monitoring/config.libsonnet
@@ -1,0 +1,13 @@
+{
+  _config+:: {
+    // volumegroup usage percentage threshold near full
+    vgUsageThresholdNearFull: 0.75,
+
+    // volumegroup usage percentage threshold critical
+    vgUsageThresholdCritical: 0.85,
+
+    // alert durations
+    volumegroupUsageThresholdAlertTime: '5m',
+  },
+}
+

--- a/monitoring/jsonnetfile.json
+++ b/monitoring/jsonnetfile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "dependencies": [],
+  "legacyImports": true
+}

--- a/monitoring/mixin.libsonnet
+++ b/monitoring/mixin.libsonnet
@@ -1,0 +1,14 @@
+(import 'config.libsonnet') +
+(import 'alerts/vgalerts.libsonnet') + {
+  prometheus+:: {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'PrometheusRule',
+        metadata: {
+          name: 'prometheus-lvmo-rules',
+        },
+        spec: {
+          groups: $.prometheusAlerts.groups,
+        },
+  }
+}
+


### PR DESCRIPTION
Adding an alert mixins framework into LVM Operator.
Makefile is modified to generate the prometheus alert yaml file.

Added 'VolumeGroupUsageAtThreshold' alert which will be triggered if
volumegroup usage goes beyond the threshold percentage (default set to 75%)

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>