### PR TITLE
Use CentOS Stream 8 for images

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vgmanager cmd/vgmanager
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o metricsexporter cmd/metricsexporter/exporter.go
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
-FROM centos:8
+FROM centos:stream8
 
 # Install required utilities
 RUN dnf install -y openssl && dnf clean all

--- a/Dockerfile.vgmanager
+++ b/Dockerfile.vgmanager
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vgmanager cmd/vgmanager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM centos:8
+FROM centos:stream8
 WORKDIR /
 COPY --from=builder /workspace/vgmanager .
 USER 65532:65532


### PR DESCRIPTION
CentOS Linux 8 repositories were removed from the mirror network on
January 31 [1]. That breaks the combined and vgmanager images, which
should switch to CentOS Stream 8.

[1] - https://lists.centos.org/pipermail/centos-devel/2021-December/098779.html