### PR TITLE
ci: build combined dockerfile as part of CI

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -41,4 +41,4 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Build operator docker image
-        run: make docker-build
+        run: make docker-build-combined

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vgmanager cmd/vgmanager
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o metricsexporter cmd/metricsexporter/exporter.go
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
-FROM centos:stream8
+FROM quay.io/centos/centos:stream8
 
 # Install required utilities
 RUN dnf install -y openssl && dnf clean all

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ docker-build: test ## Build docker image with the manager.
 docker-build-vgmanager: ## Build docker image with vgmanager.
 	docker build -f Dockerfile.vgmanager -t ${VGMANAGER_IMG} .
 
-docker-build-combined: ## Build docker image with manager and vgmanager
+docker-build-combined: test ## Build docker image with manager and vgmanager
 	docker build -f Dockerfile.combined -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
- Full repo path to centos:stream8 in Dockerfile.combined
- Add test as subtarget to docker-build-combined
- Build docker combined image as part of CI builds

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>