### PR TITLE
fix: updates lvmvolumegroupnodestatus for vg

### DIFF
--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -318,12 +318,10 @@ func setStatus(status *lvmv1alpha1.VGStatus, instance *lvmv1alpha1.LVMVolumeGrou
 	found := false
 
 	vgStatuses := instance.Spec.LVMVGStatus
-	for _, vgStatus := range vgStatuses {
+	for i, vgStatus := range vgStatuses {
 		if vgStatus.Name == status.Name {
 			found = true
-			vgStatus.Status = status.Status
-			vgStatus.Reason = status.Reason
-			vgStatus.Devices = status.Devices
+			vgStatuses[i] = *status
 			break
 		}
 	}


### PR DESCRIPTION
Fixes a bug where the lvmvolumegroupnodestatus was not updated correctly
for an existing VG. When adding a new device and restarting the
vg-manager pod, the device is added to the LVM VG but is not updated in
the lvmvolumegroupnodestatus or the LVMCluster status.

fixes: #105

Signed-off-by: N Balachandran <nibalach@redhat.com>