### PR TITLE
fix: updates prebuilt img location in doc

### DIFF
--- a/doc/usage/install.md
+++ b/doc/usage/install.md
@@ -29,7 +29,7 @@ When this is finished, you are ready to continue with the deploy steps
 If you are ok with using the prebuilt images, then just set your variable like this:
 
 ```
-export IMG=quay.io/mulbc/lvm-operator
+export IMG=quay.io/ocs-dev/lvm-operator
 ```
 
 ## Deploy


### PR DESCRIPTION
Updated the install instructions to point to the lvm-operator
image in quay.io/ocs-dev.

Signed-off-by: N Balachandran <nibalach@redhat.com>