### PR TITLE
fix: skip in-use loop devices during vgcreate/vgextend

### DIFF
--- a/pkg/internal/exec.go
+++ b/pkg/internal/exec.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	nsenterPath = "/usr/bin/nsenter"
+	losetupPath = "/usr/sbin/losetup"
 )
 
 // Executor is the  interface for running exec commands


### PR DESCRIPTION
- filter out loop devices based on Major number from lsblk
- check whether the back-file is being used by k8s for mounting block
  devices and skip using that loop device in volume groups ops

Fixes: #97

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>