### PR TITLE
fix: fix ensureCreated of lvmVG via returning an error

### DIFF
--- a/controllers/lvm_volumegroup.go
+++ b/controllers/lvm_volumegroup.go
@@ -48,6 +48,7 @@ func (c lvmVG) ensureCreated(r *LVMClusterReconciler, ctx context.Context, lvmCl
 
 		if err != nil {
 			r.Log.Error(err, "failed to reconcile LVMVolumeGroup", "name", volumeGroup.Name)
+			return err
 		} else {
 			r.Log.Info("LVMVolumeGroup", "operation", result, "name", volumeGroup.Name)
 		}


### PR DESCRIPTION
The func does not return an error if there is an error and always return
nil. Fix the same via returning and error if there is a failure.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>