### PR TITLE
ci: bump golangci-lint version to v1.45.2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or
           # v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>