### PR TITLE
fix: add snapshot related commands in must-gather

### DIFF
--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -23,6 +23,8 @@ commands_get+=("infrastructures.config")
 commands_get+=("clusterrole")
 commands_get+=("clusterrolebinding")
 commands_get+=("scc")
+commands_get+=("volumesnapshotclass")
+commands_get+=("volumesnapshotcontent")
 
 # collect yaml output of OC commands
 oc_yamls=()
@@ -35,6 +37,8 @@ oc_yamls+=("infrastructures.config")
 oc_yamls+=("clusterrole")
 oc_yamls+=("clusterrolebinding")
 oc_yamls+=("scc")
+oc_yamls+=("volumesnapshotclass")
+oc_yamls+=("volumesnapshotcontent")
 
 
 # collect describe output of OC commands
@@ -48,6 +52,8 @@ commands_desc+=("infrastructures.config")
 commands_desc+=("clusterrole")
 commands_desc+=("clusterrolebinding")
 commands_desc+=("scc")
+commands_desc+=("volumesnapshotclass")
+commands_desc+=("volumesnapshotcontent")
 
 # collection path for OC commands
 mkdir -p "${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/"

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -50,13 +50,10 @@ commands_desc+=("lvmvolumegroup")
 commands_desc+=("lvmvolumegroupsnodestatus")
 commands_desc+=("pods")
 
-
-
 # collect yaml output of OC commands
 oc_yamls=()
 oc_yamls+=("csv")
 oc_yamls+=("installplan")
-
 
 echo "collecting dump of namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
 oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
@@ -102,3 +99,9 @@ done
 echo "collecting dump of oc get pvc all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
 { oc get pvc --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
 { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+
+# For snapshot of all namespaces
+echo "collecting dump of snapshot information for all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get volumesnapshot --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
+{ oc describe volumesnapshot --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1


### PR DESCRIPTION
Add commands in must-gather to capture snapshot related
kubernetes objects.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>