### PR TITLE
feat: adds alerts for thin pool usage

### DIFF
--- a/config/prometheus/prometheus_rules.yaml
+++ b/config/prometheus/prometheus_rules.yaml
@@ -24,3 +24,41 @@
       "for": "5m"
       "labels":
         "severity": "critical"
+  - "name": "thin-pool-alert.rules"
+    "rules":
+    - "alert": "ThinPoolDataUsageAtThresholdNearFull"
+      "annotations":
+        "description": "Thin pool in the VolumeGroup is nearing full. Data deletion or thin pool expansion is required."
+        "message": "Thin Pool data utilization in the VolumeGroup {{ $labels.device_class }} has crossed 75 % on node {{ $labels.node }}. Free up some space or expand the thin pool."
+      "expr": |
+        topolvm_thinpool_data_percent > 75.00  and topolvm_thinpool_data_percent < 85.00
+      "for": "5m"
+      "labels":
+        "severity": "warning"
+    - "alert": "ThinPoolDataUsageAtThresholdCritical"
+      "annotations":
+        "description": "Thin pool in the VolumeGroup is critically full. Data deletion or thin pool expansion is required."
+        "message": "Thin Pool data utilization in the VolumeGroup {{ $labels.device_class }} has crossed 85 % on node {{ $labels.node }}. Free up some space or expand the thin pool immediately."
+      "expr": |
+        topolvm_thinpool_data_percent > 85.00
+      "for": "5m"
+      "labels":
+        "severity": "critical"
+    - "alert": "ThinPoolMetaDataUsageAtThresholdNearFull"
+      "annotations":
+        "description": "Thin pool metadata utitlization in the VolumeGroup is nearing full. Data deletion or thin pool expansion is required."
+        "message": "Thin Pool metadata utilization in the VolumeGroup {{ $labels.device_class }} has crossed 75 % on node {{ $labels.node }}. Free up some space or expand the thin pool."
+      "expr": |
+        topolvm_thinpool_metadata_percent > 75.00  and topolvm_thinpool_data_percent < 85.00
+      "for": "5m"
+      "labels":
+        "severity": "warning"
+    - "alert": "ThinPoolMetaDataUsageAtThresholdCritical"
+      "annotations":
+        "description": "Thin pool metadata ultilization in the VolumeGroup is critically full. Data deletion or thin pool expansion is required."
+        "message": "Thin Pool metadata utilization in the VolumeGroup {{ $labels.device_class }} has crossed 85 % on node {{ $labels.node }}. Free up some space or expand the thin pool immediately."
+      "expr": |
+        topolvm_thinpool_metadata_percent > 85.00
+      "for": "5m"
+      "labels":
+        "severity": "critical"

--- a/monitoring/alerts/vgalerts.libsonnet
+++ b/monitoring/alerts/vgalerts.libsonnet
@@ -34,6 +34,67 @@
           },
 	],
       },
+      {
+        name: 'thin-pool-alert.rules',
+        rules: [
+          {
+            alert: 'ThinPoolDataUsageAtThresholdNearFull',
+            expr: |||
+              topolvm_thinpool_data_percent > %(thinPoolUsageThresholdNearFull)0.2f  and topolvm_thinpool_data_percent < %(thinPoolUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.thinPoolUsageThresholdAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Thin pool in the VolumeGroup is nearing full. Data deletion or thin pool expansion is required.',
+              message: 'Thin Pool data utilization in the VolumeGroup {{ $labels.device_class }} has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the thin pool.' % ($._config.thinPoolUsageThresholdNearFull),
+            },
+          },
+          {
+            alert: 'ThinPoolDataUsageAtThresholdCritical',
+            expr: |||
+              topolvm_thinpool_data_percent > %(thinPoolUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.thinPoolUsageThresholdAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              description: 'Thin pool in the VolumeGroup is critically full. Data deletion or thin pool expansion is required.',
+              message: 'Thin Pool data utilization in the VolumeGroup {{ $labels.device_class }} has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the thin pool immediately.' % ($._config.thinPoolUsageThresholdCritical),
+            },
+          },
+          {
+            alert: 'ThinPoolMetaDataUsageAtThresholdNearFull',
+            expr: |||
+              topolvm_thinpool_metadata_percent > %(thinPoolUsageThresholdNearFull)0.2f  and topolvm_thinpool_data_percent < %(thinPoolUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.thinPoolUsageThresholdAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Thin pool metadata utitlization in the VolumeGroup is nearing full. Data deletion or thin pool expansion is required.',
+              message: 'Thin Pool metadata utilization in the VolumeGroup {{ $labels.device_class }} has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the thin pool.' % ($._config.thinPoolUsageThresholdNearFull),
+            },
+          },
+          {
+            alert: 'ThinPoolMetaDataUsageAtThresholdCritical',
+            expr: |||
+              topolvm_thinpool_metadata_percent > %(thinPoolUsageThresholdCritical)0.2f
+            ||| % $._config,
+            'for': $._config.thinPoolUsageThresholdAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              description: 'Thin pool metadata ultilization in the VolumeGroup is critically full. Data deletion or thin pool expansion is required.',
+              message: 'Thin Pool metadata utilization in the VolumeGroup {{ $labels.device_class }} has crossed %.0f %% on node {{ $labels.node }}. Free up some space or expand the thin pool immediately.' % ($._config.thinPoolUsageThresholdCritical),
+            },
+          },
+	],
+      },
     ],
   },
 }

--- a/monitoring/config.libsonnet
+++ b/monitoring/config.libsonnet
@@ -8,6 +8,14 @@
 
     // alert durations
     volumegroupUsageThresholdAlertTime: '5m',
+
+    // thin pool data and metadata usage percentage threshold near full
+    thinPoolUsageThresholdNearFull : 75,
+
+    // thin pool data and metadata usage percentage threshold critical
+    thinPoolUsageThresholdCritical : 85,
+
+    // alert durations
+    thinPoolUsageThresholdAlertTime: '5m',
   },
 }
-


### PR DESCRIPTION
Adds alerts for thin pool data and metadata usage.
Provides near full (75%) and critical (85%) usage alerts.

Note: We don't have thin pool name in the alerts since topolvm does not provide it as of now.  But since we support only one thin pool per volume group, current alerts should suffice (IMO). 
We can update it to include thin pool names once topolvm shows thin pool name in the metric labels. 

Tested with lower thresholds.
![Screenshot from 2022-04-20 12-40-22](https://user-images.githubusercontent.com/9363998/164171783-55b8ba00-4e5f-48c3-b5b0-8640553aad35.png)

![Screenshot from 2022-04-20 12-41-04](https://user-images.githubusercontent.com/9363998/164174117-b617cc78-9547-4d5a-894c-945fa909051f.png)



Signed-off-by: Santosh Pillai <sapillai@redhat.com>