### PR TITLE
fix e2e: added thin pool configuration to lvm cluster used by e2e tests

### DIFF
--- a/pkg/deploymanager/LVMCluster.go
+++ b/pkg/deploymanager/LVMCluster.go
@@ -18,6 +18,11 @@ func (t *DeployManager) GenerateLVMCluster() *v1alpha1.LVMCluster {
 				DeviceClasses: []v1alpha1.DeviceClass{
 					{
 						Name: "vg1",
+						ThinPoolConfig: &v1alpha1.ThinPoolConfig{
+							Name:               "mytp1",
+							SizePercent:        50,
+							OverprovisionRatio: 50,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Updated the sample LVMCluster CR used by e2e tests with the thin pool configuration.

Signed-off-by: riya-singhal31 <riyasinghalji@gmail.com>