### PR TITLE
fix: fix labels for topolvm-node-metrics service

### DIFF
--- a/config/rbac/topolvm_metric_service_config.yaml
+++ b/config/rbac/topolvm_metric_service_config.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/compose: metrics
 spec:
   selector:
-    app: topolvm-node
+    app.lvm.openshift.io: topolvm-node
   ports:
     - name: topolvm-metrics
       protocol: TCP


### PR DESCRIPTION
Updates the `service` config to use the new label key `app.lvm.openshift.io`. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>