### PR TITLE
fix: update topolvm csi image to 0.11.0

### DIFF
--- a/bundle/manifests/lvm-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/lvm-operator-manager-config_v1_configmap.yaml
@@ -5,7 +5,7 @@ data:
   CSI_REGISTRAR_IMAGE: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
   CSI_RESIZER_IMAGE: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
   OPERATOR_NAMESPACE: openshift-storage
-  TOPOLVM_CSI_IMAGE: quay.io/topolvm/topolvm:0.10.3
+  TOPOLVM_CSI_IMAGE: quay.io/topolvm/topolvm:0.11.0
   VGMANAGER_IMAGE: quay.io/ocs-dev/vgmanager:latest
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1

--- a/config/manager/manager.env
+++ b/config/manager/manager.env
@@ -1,5 +1,5 @@
 OPERATOR_NAMESPACE=openshift-storage
-TOPOLVM_CSI_IMAGE=quay.io/topolvm/topolvm:0.10.3
+TOPOLVM_CSI_IMAGE=quay.io/topolvm/topolvm:0.11.0
 CSI_REGISTRAR_IMAGE=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
 CSI_PROVISIONER_IMAGE=k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 CSI_LIVENESSPROBE_IMAGE=k8s.gcr.io/sig-storage/livenessprobe:v2.5.0

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -23,7 +23,7 @@ import (
 var (
 	defaultValMap = map[string]string{
 		"OPERATOR_NAMESPACE":      "openshift-storage",
-		"TOPOLVM_CSI_IMAGE":       "quay.io/topolvm/topolvm:0.10.3",
+		"TOPOLVM_CSI_IMAGE":       "quay.io/topolvm/topolvm:0.11.0",
 		"CSI_REGISTRAR_IMAGE":     "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0",
 		"CSI_PROVISIONER_IMAGE":   "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0",
 		"CSI_LIVENESSPROBE_IMAGE": "k8s.gcr.io/sig-storage/livenessprobe:v2.5.0",


### PR DESCRIPTION
Topolvm image was updated to 0.11.0 only in go.mod and makefile.
This PR updates the image version in all the required places.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>