### PR TITLE
add suggested namespace to csv

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -45,6 +45,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/suggested-namespace: openshift-storage
   name: lvm-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
This is so that operator is always installed in openshift-storage
namespace.

see https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-generating-csvs.html#osdk-suggested-namespace_osdk-generating-csvs
