### PR TITLE
fix: update csv correctly.

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -27,11 +27,12 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     categories: Storage
     operatorframework.io/suggested-namespace: openshift-storage
-    operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com",
+      "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: lvm-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,6 +4,9 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: Storage
+    operatorframework.io/suggested-namespace: openshift-storage
+    operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
   name: @BUNDLE_PACKAGE@.v0.0.0
   namespace: placeholder
 spec:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,6 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - lvm_v1alpha1_lvmcluster.yaml
-- lvm_v1alpha1_lvmvolumegroup.yaml
-- lvm_v1alpha1_lvmvolumegroupnodestatus.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
CSV was updated directly under the manifests directory. This PR fixes
it. Makes correct changes and runs `make bundle` to auto generate the
csv file.

Following changes are made the the csv:
1. Add suggested namespace annotation.
2. Add category
3. Mark certain CRDs as internal so that they are not visible in the UI.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>