### PR TITLE
fix: cleanup when pvcs are deleted

### DIFF
--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -149,8 +149,6 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 		}
 		if err != nil {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 1}, err
-		} else {
-			return reconcile.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
The LVMCluster controller does not cleanup lvm resources
if there are PVCs provisioned by topolvm still existing when the
LVMCluster CR is deleted. This commit fixes an issue where the
LVMCluster finalizer is not removed even after the PVCs are deleted,
thus preventing the reseources from being cleaned up.

Signed-off-by: N Balachandran <nibalach@redhat.com>