### PR TITLE
[WIP] fix: add cluster monitoring annotation in csv

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -247,18 +247,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
@@ -308,6 +296,18 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
               - command:
                 - /metricsexporter
                 image: quay.io/ocs-dev/lvm-operator:latest

--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "lvm.topolvm.io/v1alpha1",
           "kind": "LVMCluster",
           "metadata": {
-            "name": "lvmcluster-sample"
+            "name": "odf-lvmcluster"
           },
           "spec": {
             "storage": {
@@ -17,8 +17,8 @@ metadata:
                   "name": "vg1",
                   "thinPoolConfig": {
                     "name": "thin-pool-1",
-                    "overprovisionRatio": 50,
-                    "sizePercent": 50
+                    "overprovisionRatio": 10,
+                    "sizePercent": 90
                   }
                 }
               ]
@@ -28,11 +28,38 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Storage
+    containerImage: quay.io/ocs-dev/lvm-operator:latest
+    description: The ODF LVM Operator manages local storage using LVM
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/initialization-resource: |-
+      {
+          "apiVersion": "lvm.topolvm.io/v1alpha1",
+          "kind": "LVMCluster",
+          "metadata": {
+            "name": "odf-lvmcluster"
+          },
+          "spec": {
+            "storage": {
+              "deviceClasses": [
+                {
+                  "name": "vg1",
+                  "thinPoolConfig": {
+                    "name": "thin-pool-1",
+                    "overprovisionRatio": 10,
+                    "sizePercent": 90
+                  }
+                }
+              ]
+            }
+          }
+        }
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com",
       "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/red-hat-storage/lvm-operator
+    support: Red Hat
   name: lvm-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
Add `operatorframework.io/cluster-monitoring: "true"` in the CSV.
This enables the radio button in the console UI to enable monitoring
while installing the operator.

![Screenshot from 2022-05-17 12-30-04](https://user-images.githubusercontent.com/9363998/168749542-25c295d4-4dfe-4f82-aeac-055f1aa6a9a4.png)

![Screenshot from 2022-05-17 12-19-45](https://user-images.githubusercontent.com/9363998/168749583-7e1b6e2c-fca4-475d-a1c6-add8894546f5.png)

![Screenshot from 2022-05-17 12-20-35](https://user-images.githubusercontent.com/9363998/168749611-2b73a222-24d7-41c2-b7ea-76f99411aca2.png)

![Screenshot from 2022-05-17 12-21-20](https://user-images.githubusercontent.com/9363998/168749693-d80b8a33-03a8-4aa7-890c-a3c9359dc62f.png)


Signed-off-by: Santosh Pillai <sapillai@redhat.com>