### PR TITLE
Bug 2083129: update csv correctly

### DIFF
--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,6 +4,9 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: Storage
+    operatorframework.io/suggested-namespace: openshift-storage
+    operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
   name: @BUNDLE_PACKAGE@.v0.0.0
   namespace: placeholder
 spec:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,6 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - lvm_v1alpha1_lvmcluster.yaml
-- lvm_v1alpha1_lvmvolumegroup.yaml
-- lvm_v1alpha1_lvmvolumegroupnodestatus.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
CSV was updated directly under the manifests directory. This PR fixes
it. Makes correct changes and runs `make bundle` to auto generate the
csv file.

Following changes are made the the csv:
1. Add suggested namespace annotation.
2. Add category
3. Mark certain CRDs as internal so that they are not visible in the UI.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 2ffe7ccec0f8fed466f51bf37beb65e91d15174b)