### PR TITLE
fix: specify the go version to be used

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -6,6 +6,8 @@ on:
     branches: ['*']
   pull_request:
     branches: ['*']
+env:
+  GO_VERSION: "1.16"
 
 jobs:
   golangci-lint:
@@ -13,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
@@ -35,7 +42,7 @@ jobs:
           # only-new-issues: true
 
           # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
+          skip-go-installation: true
 
           # Optional: if set to true then the action don't cache or
           # restore ~/go/pkg.


### PR DESCRIPTION
Updates the golangci-lint github workflow to specify the version
of go to be used.

Signed-off-by: N Balachandran <nibalach@redhat.com>