### PR TITLE
chore: github action to build the operator every week

### DIFF
--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -1,0 +1,51 @@
+name: LVMO Weekly Image Publish
+
+# Runs every Monday at 23:00 UTC
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * 1"
+env:
+  GO_VERSION: "1.17"
+  IMG: "quay.io/ocs-dev/lvm-operator:weekly"
+
+jobs:
+  build-and-publish-image:
+    name: Build and publish the LVMO image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v2
+
+      # 'test' is a sub-target of 'docker-build' and so cache go build & mod
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Login to quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_LVMO_ROBOT_NAME }}
+          password: ${{ secrets.QUAY_LVMO_ROBOT_TOKEN }}
+
+      - name: Build operator docker image
+        run: make docker-build-combined IMG=${{env.IMG}}
+
+      - name: Publish operator image
+        run: docker push IMG=${{env.IMG}}


### PR DESCRIPTION
This adds a github action to build and push the operator
image to quay every Monday.

Signed-off-by: N Balachandran <nibalach@redhat.com>