### PR TITLE
fix: creates the thinpool with the -Z option

### DIFF
--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -259,7 +259,7 @@ func (r *VGReconciler) addThinPoolToVG(vgName string, config *lvmv1alpha1.ThinPo
 		}
 	}
 
-	args := []string{"-l", fmt.Sprintf("%d%%FREE", config.SizePercent), "-c", DefaultChunkSize, "-T", fmt.Sprintf("%s/%s", vgName, config.Name)}
+	args := []string{"-l", fmt.Sprintf("%d%%FREE", config.SizePercent), "-c", DefaultChunkSize, "-Z", "y", "-T", fmt.Sprintf("%s/%s", vgName, config.Name)}
 
 	_, err = r.executor.ExecuteCommandWithOutputAsHost(lvCreateCmd, args...)
 	if err != nil {


### PR DESCRIPTION
This commit updates the lvcreate command used to create
the thinpool with the -Z option to enable zeroing. This removes
the requirement that the thin_pool_zero option be enabled in the
lvm.conf.

Signed-off-by: N Balachandran <nibalach@redhat.com>