### PR TITLE
send vg alerts only when thin pool alerts are also triggered

### DIFF
--- a/bundle/manifests/prometheus-lvmo-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/prometheus-lvmo-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -13,7 +13,7 @@ spec:
         message: VolumeGroup {{ $labels.device_class }} utilization has crossed 75
           % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup.
       expr: |
-        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.75 and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= 0.85
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.75 and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= 0.85 and topolvm_thinpool_data_percent > 75.00  and topolvm_thinpool_data_percent < 85.00
       for: 5m
       labels:
         severity: warning
@@ -25,7 +25,7 @@ spec:
           % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup
           immediately.
       expr: |
-        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.85
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.85 and topolvm_thinpool_data_percent > 85.00
       for: 5m
       labels:
         severity: critical

--- a/config/prometheus/prometheus_rules.yaml
+++ b/config/prometheus/prometheus_rules.yaml
@@ -11,7 +11,7 @@
         "description": "VolumeGroup is nearing full. Data deletion or VolumeGroup expansion is required."
         "message": "VolumeGroup {{ $labels.device_class }} utilization has crossed 75 % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup."
       "expr": |
-        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.75 and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= 0.85
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.75 and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= 0.85 and topolvm_thinpool_data_percent > 75.00  and topolvm_thinpool_data_percent < 85.00
       "for": "5m"
       "labels":
         "severity": "warning"
@@ -20,7 +20,7 @@
         "description": "VolumeGroup is critically full. Data deletion or VolumeGroup expansion is required."
         "message": "VolumeGroup {{ $labels.device_class }} utilization has crossed 85 % on node {{ $labels.node }}. Free up some space or expand the VolumeGroup immediately."
       "expr": |
-        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.85
+        (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > 0.85 and topolvm_thinpool_data_percent > 85.00
       "for": "5m"
       "labels":
         "severity": "critical"

--- a/monitoring/alerts/vgalerts.libsonnet
+++ b/monitoring/alerts/vgalerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'VolumeGroupUsageAtThresholdNearFull',
             expr: |||
-              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdNearFull)0.2f and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= %(vgUsageThresholdCritical)0.2f
+              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdNearFull)0.2f and (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes <= %(vgUsageThresholdCritical)0.2f and topolvm_thinpool_data_percent > %(thinPoolUsageThresholdNearFull)0.2f  and topolvm_thinpool_data_percent < %(thinPoolUsageThresholdCritical)0.2f
             ||| % $._config,
             'for': $._config.volumegroupUsageThresholdAlertTime,
             labels: {
@@ -21,7 +21,7 @@
           {
             alert: 'VolumeGroupUsageAtThresholdCritical',
             expr: |||
-              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdCritical)0.2f
+              (topolvm_volumegroup_size_bytes - topolvm_volumegroup_available_bytes)/topolvm_volumegroup_size_bytes > %(vgUsageThresholdCritical)0.2f and topolvm_thinpool_data_percent > %(thinPoolUsageThresholdCritical)0.2f
             ||| % $._config,
             'for': $._config.volumegroupUsageThresholdAlertTime,
             labels: {


### PR DESCRIPTION
Trigger VolumeGroupUsage alerts only if actual size is occupied via the thin pool.
`VolumeGroupUsageAtThresholdNearFull` will be sent when used VG size and
thin pool size exceeds 75%.

`VolumeGroupUsageAtThresholdCritical` will be sent when VG size and thin
pool size exceeds 85%.

Testing
 
Current behavior: size-percent is 90
```
sh-4.4# vgs
  VG  #PV #LV #SN Attr   VSize  VFree
  vg3   1   1   0 wz--n- <1.46t 149.04g
sh-4.4# lvs
  LV          VG  Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  thin-pool-3 vg3 twi-a-tz-- <1.31t             0.00   9.94
```
- VG critical alert trigger even though thin pool is not using any real space.
![Screenshot from 2022-06-13 11-40-25](https://user-images.githubusercontent.com/9363998/173304315-0b36abe1-da2e-47c6-a779-580c47f7e26e.png)


------------------------------------------------------------------------------------------------------------
Behavior after this PR: 
- size percent is 90
```
sh-4.4# vgs
  VG  #PV #LV #SN Attr   VSize  VFree  
  vg4   1   1   0 wz--n- <1.46t 149.04g
sh-4.4# lvs
  LV          VG  Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  thin-pool-4 vg4 twi-a-tz-- <1.31t             0.00   9.94                            
sh-4.4# 
```

- No VG critical alert triggered.

![Screenshot from 2022-06-13 12-22-38](https://user-images.githubusercontent.com/9363998/173304361-310da164-bb37-4618-aebc-fcaef2f2ca54.png)


- Thin pool used data bytes cross 85%

```
sh-4.4# vgs
  VG  #PV #LV #SN Attr   VSize  VFree  
  vg4   1   2   0 wz--n- <1.46t 149.04g
sh-4.4# lvs
  LV                                   VG  Attr       LSize  Pool        Origin Data%  Meta%  Move Log Cpy%Sync Convert
  fa87dbd5-b437-40b8-8fd1-827a464df10a vg4 Vwi-aotz--  1.27t thin-pool-4        92.93                                  
  thin-pool-4                          vg4 twi-aotz-- <1.31t                    90.37  56.11   
```
Both thin pool and vg alerts are triggered.
![Screenshot from 2022-06-13 13-10-45](https://user-images.githubusercontent.com/9363998/173304460-c54d697d-5e1a-49ed-9f28-13e3fc7cfad7.png)
