### PR TITLE
fix: update resource request and limits across containers

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -327,18 +327,24 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 200m
+                    cpu: 100m
                     memory: 100Mi
                   requests:
-                    cpu: 100m
-                    memory: 20Mi
+                    cpu: 50m
+                    memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               - command:
                 - /metricsexporter
                 image: quay.io/ocs-dev/lvm-operator:latest
                 name: metricsexporter
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 100Mi
+                  requests:
+                    cpu: 30m
+                    memory: 30Mi
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,11 +50,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 100Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 50m
+            memory: 50Mi
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -68,5 +68,12 @@ spec:
         - /metricsexporter
         image: controller:latest
         name: metricsexporter
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 30m
+            memory: 30Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -70,25 +70,51 @@ var (
 
 	// CSI Controller resource requests/limits
 	// TODO: Reduce these values and reach optimistic values without effecting performance
-	TopolvmControllerMemRequest = "250Mi"
-	TopolvmControllerMemLimit   = "250Mi"
-	TopolvmControllerCPURequest = "250m"
-	TopolvmControllerCPULimit   = "250m"
+	TopolvmControllerMemRequest = "100Mi"
+	TopolvmControllerMemLimit   = "150Mi"
+	TopolvmControllerCPURequest = "100m"
+	TopolvmControllerCPULimit   = "100m"
 
-	TopolvmCsiProvisionerMemRequest = "100Mi"
+	TopolvmCsiProvisionerMemRequest = "50Mi"
 	TopolvmCsiProvisionerMemLimit   = "100Mi"
-	TopolvmCsiProvisionerCPURequest = "100m"
+	TopolvmCsiProvisionerCPURequest = "50m"
 	TopolvmCsiProvisionerCPULimit   = "100m"
 
-	TopolvmCsiResizerMemRequest = "100Mi"
+	TopolvmCsiResizerMemRequest = "50Mi"
 	TopolvmCsiResizerMemLimit   = "100Mi"
-	TopolvmCsiResizerCPURequest = "100m"
-	TopolvmCsiResizerCPULimit   = "100m"
+	TopolvmCsiResizerCPURequest = "20m"
+	TopolvmCsiResizerCPULimit   = "50m"
 
-	TopolvmCsiSnapshotterMemRequest = "100Mi"
+	TopolvmCsiSnapshotterMemRequest = "50Mi"
 	TopolvmCsiSnapshotterMemLimit   = "100Mi"
-	TopolvmCsiSnapshotterCPURequest = "100m"
-	TopolvmCsiSnapshotterCPULimit   = "100m"
+	TopolvmCsiSnapshotterCPURequest = "20m"
+	TopolvmCsiSnapshotterCPULimit   = "50m"
+
+	VgManagerMemRequest = "50Mi"
+	VgManagerMemLimit   = "100Mi"
+	VgManagerCPURequest = "30m"
+	VgManagerCPULimit   = "50m"
+
+	// topoLVM Node resource requests/limits
+	TopolvmNodeMemRequest = "150Mi"
+	TopolvmNodeMemLimit   = "200Mi"
+	TopolvmNodeCPURequest = "50m"
+	TopolvmNodeCPULimit   = "100m"
+
+	TopolvmdMemRequest = "100Mi"
+	TopolvmdMemLimit   = "150Mi"
+	TopolvmdCPURequest = "150m"
+	TopolvmdCPULimit   = "200m"
+
+	CSIRegistrarMemRequest = "30Mi"
+	CSIRegistrarMemLimit   = "50Mi"
+	CSIRegistrarCPURequest = "20m"
+	CSIRegistrarCPULimit   = "30m"
+
+	LivenessProbeMemRequest = "30Mi"
+	LivenessProbeMemLimit   = "50Mi"
+	LivenessProbeCPURequest = "30m"
+	LivenessProbeCPULimit   = "50m"
 
 	// CSI Provisioner requires below environment values to make use of CSIStorageCapacity
 	PodNameEnv   = "POD_NAME"
@@ -101,12 +127,6 @@ var (
 	NodeContainerName               = "topolvm-node"
 	TopolvmNodeContainerHealthzName = "healthz"
 	LvmdConfigFile                  = "/etc/topolvm/lvmd.yaml"
-
-	// topoLVM Node resource requests/limits
-	TopolvmNodeMemRequest = "250Mi"
-	TopolvmNodeMemLimit   = "250Mi"
-	TopolvmNodeCPURequest = "250m"
-	TopolvmNodeCPULimit   = "250m"
 
 	DefaultCSISocket  = "/run/topolvm/csi-topolvm.sock"
 	DefaultLVMdSocket = "/run/lvmd/lvmd.sock"

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -368,6 +368,16 @@ func getCsiSnapshotterContainer() *corev1.Container {
 }
 
 func getLivenessProbeContainer() *corev1.Container {
+	resourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPULimit),
+			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPURequest),
+			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemRequest),
+		},
+	}
 
 	// csi liveness probe container
 	args := []string{
@@ -383,6 +393,7 @@ func getLivenessProbeContainer() *corev1.Container {
 		Image:        CsiLivenessProbeImage,
 		Args:         args,
 		VolumeMounts: volumeMounts,
+		Resources:    resourceRequirements,
 	}
 	return livenessProbe
 }

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -242,12 +242,12 @@ func getLvmdContainer() *corev1.Container {
 
 	resourceRequirements := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemLimit),
+			corev1.ResourceCPU:    resource.MustParse(TopolvmdCPULimit),
+			corev1.ResourceMemory: resource.MustParse(TopolvmdMemLimit),
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPURequest),
-			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemRequest),
+			corev1.ResourceCPU:    resource.MustParse(TopolvmdCPURequest),
+			corev1.ResourceMemory: resource.MustParse(TopolvmdMemRequest),
 		},
 	}
 
@@ -354,17 +354,40 @@ func getCsiRegistrarContainer() *corev1.Container {
 		"rm -rf /registration/topolvm.cybozu.com /registration/topolvm.cybozu.com-reg.sock",
 	}
 
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(CSIRegistrarCPULimit),
+			corev1.ResourceMemory: resource.MustParse(CSIRegistrarMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(CSIRegistrarCPURequest),
+			corev1.ResourceMemory: resource.MustParse(CSIRegistrarMemRequest),
+		},
+	}
+
 	csiRegistrar := &corev1.Container{
 		Name:         "csi-registrar",
 		Image:        CsiRegistrarImage,
 		Args:         args,
 		Lifecycle:    &corev1.Lifecycle{PreStop: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: preStopCmd}}},
 		VolumeMounts: volumeMounts,
+		Resources:    requirements,
 	}
 	return csiRegistrar
 }
 
 func getNodeLivenessProbeContainer() *corev1.Container {
+	resourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPULimit),
+			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPURequest),
+			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemRequest),
+		},
+	}
+
 	args := []string{
 		fmt.Sprintf("--csi-address=%s", DefaultCSISocket),
 	}
@@ -378,6 +401,7 @@ func getNodeLivenessProbeContainer() *corev1.Container {
 		Image:        CsiLivenessProbeImage,
 		Args:         args,
 		VolumeMounts: volumeMounts,
+		Resources:    resourceRequirements,
 	}
 	return liveness
 }

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -22,6 +22,7 @@ import (
 	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,6 +133,17 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 	command := []string{
 		"/vgmanager",
 	}
+
+	resourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(VgManagerCPULimit),
+			corev1.ResourceMemory: resource.MustParse(VgManagerMemLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(VgManagerCPURequest),
+			corev1.ResourceMemory: resource.MustParse(VgManagerMemRequest),
+		},
+	}
 	containers := []corev1.Container{
 		{
 			Name:    VGManagerUnit,
@@ -142,6 +154,7 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 				RunAsUser:  &zero,
 			},
 			VolumeMounts: volumeMounts,
+			Resources:    resourceRequirements,
 			Env: []corev1.EnvVar{
 				{
 					Name: "NODE_NAME",


### PR DESCRIPTION
[Reference doc](https://docs.google.com/spreadsheets/d/1GGjmVCDezVyay0jzKKAqyGxuDOU6ud68vB__FJ-mHJc/edit#gid=324255029)


------------------------------

Testing:

1. 50 POD/PVC

- No OOMKilled error observed. But looks like lvmd container might have restarted in the topolvm-node pod.
- It took 20 minutes (approximately double the current time) to create 50 pods.

``` Every 2.0s: oc get pods                                                 localhost.localdomain: Fri Jun 17 14:54:14 2022

NAME                                               READY   STATUS    RESTARTS       AGE
lvm-operator-controller-manager-5d69d47698-b5qm8   3/3     Running   0              49m
topolvm-controller-55d8fd4665-cxlbh                5/5     Running   0              48m
topolvm-node-f2vbw                                 4/4     Running   2 (4m6s ago)   48m
vg-manager-dr65q                                   1/1     Running   0              48m
```

``` Usage report: 50 pods in namespace openshift-storage using 50 PVCs with Storage Class <odf-lvm-vg7>
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Pod lvm-operator-controller-manager-5d69d47698-b5qm8 between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0030 |     0.0103 |     0.0054
	 MEM (min|max|avg) Mib    :    50.4141 |    53.8828 |    52.0765
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container kube-rbac-proxy between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :     9.2578 |     9.2773 |     9.2716
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container manager between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0025 |     0.0092 |     0.0046
	 MEM (min|max|avg) Mib    :    24.5664 |    25.7930 |    25.1808
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container metricsexporter between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0027 |     0.0006
	 MEM (min|max|avg) Mib    :    16.1836 |    18.8750 |    17.6241
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Pod topolvm-controller-55d8fd4665-cxlbh between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0059 |     0.0681 |     0.0181
	 MEM (min|max|avg) Mib    :   124.3398 |   133.3516 |   130.0202
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container liveness-probe between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :     8.5508 |     9.1797 |     8.7374
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container topolvm-controller between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0023 |     0.0317 |     0.0090
	 MEM (min|max|avg) Mib    :    40.6523 |    43.1602 |    42.4560
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-provisioner between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0008 |     0.0321 |     0.0068
	 MEM (min|max|avg) Mib    :    33.9336 |    37.8086 |    35.6828
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-resizer between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0065 |     0.0017
	 MEM (min|max|avg) Mib    :    27.3398 |    32.3438 |    30.2547
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-snapshotter between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0003
	 MEM (min|max|avg) Mib    :    12.7852 |    13.0273 |    12.8892
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Pod topolvm-node-f2vbw between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0044 |     0.1464 |     0.0899
	 MEM (min|max|avg) Mib    :    64.3477 |   201.3359 |   108.6380
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container csi-registrar between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :    12.6367 |    12.8750 |    12.7168
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container liveness-probe between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :     7.6797 |     8.2422 |     7.9346
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container lvmd between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0005 |     0.1368 |     0.0781
	 MEM (min|max|avg) Mib    :    22.1797 |   127.1211 |    44.1463
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container topolvm-node between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0020 |     0.0373 |     0.0114
	 MEM (min|max|avg) Mib    :     0.0000 |    53.2891 |    43.8404
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Pod vg-manager-dr65q between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0022 |     0.0009
	 MEM (min|max|avg) Mib    :    20.1328 |    21.3594 |    20.6117
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Container vg-manager between 2022-06-17 14:30:36 +0530 IST and 2022-06-17 14:50:09 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0022 |     0.0009
	 MEM (min|max|avg) Mib    :    20.1328 |    21.3594 |    20.6117
--------------------------------------------------------------------------------
``` 


2. Updated CPU request and limit for provisioner and lvm container.  Tested with 20, 40, 45 and 50 pod/pvcs. No pod restart observed.

``` 
Usage report: 20 pods in namespace openshift-storage using 20 PVCs with Storage Class <odf-lvm-vg1>
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Pod lvm-operator-controller-manager-959d89f47-9mbvd between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0023 |     0.0099 |     0.0057
	 MEM (min|max|avg) Mib    :    55.4609 |    59.1016 |    56.7630
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container metricsexporter between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0054 |     0.0008
	 MEM (min|max|avg) Mib    :    19.2031 |    22.5391 |    20.2455
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container kube-rbac-proxy between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0007 |     0.0002
	 MEM (min|max|avg) Mib    :     9.7031 |     9.7031 |     9.7031
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container manager between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0017 |     0.0069 |     0.0047
	 MEM (min|max|avg) Mib    :    26.3281 |    27.3672 |    26.8143
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Pod topolvm-controller-cf7f49c87-jzw7c between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0057 |     0.0365 |     0.0186
	 MEM (min|max|avg) Mib    :   105.5195 |   117.2305 |   113.3366
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-resizer between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0042 |     0.0020
	 MEM (min|max|avg) Mib    :    24.2852 |    26.4141 |    25.4326
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-snapshotter between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0009 |     0.0003
	 MEM (min|max|avg) Mib    :    12.9141 |    13.0703 |    12.9880
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container liveness-probe between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :    10.7695 |    11.2578 |    11.0451
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container topolvm-controller between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0026 |     0.0226 |     0.0098
	 MEM (min|max|avg) Mib    :    35.0352 |    36.6680 |    35.6567
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-provisioner between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0012 |     0.0210 |     0.0063
	 MEM (min|max|avg) Mib    :    22.3594 |    29.8359 |    28.2142
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Pod topolvm-node-4pslc between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0014 |     0.1961 |     0.1027
	 MEM (min|max|avg) Mib    :    73.6875 |   120.6641 |    97.0545
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container csi-registrar between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0004 |     0.0001
	 MEM (min|max|avg) Mib    :     6.8750 |     7.0234 |     6.9332
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container liveness-probe between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0006 |     0.0002
	 MEM (min|max|avg) Mib    :     9.0391 |     9.0586 |     9.0485
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container lvmd between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.1828 |     0.0931
	 MEM (min|max|avg) Mib    :    19.9688 |    57.2578 |    36.9173
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container topolvm-node between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0012 |     0.0169 |     0.0093
	 MEM (min|max|avg) Mib    :    37.7500 |    47.3242 |    44.1556
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Pod vg-manager-jhd8k between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0005 |     0.0016 |     0.0009
	 MEM (min|max|avg) Mib    :    20.7266 |    21.2734 |    21.0947
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Container vg-manager between 2022-06-20 17:49:16 +0530 IST and 2022-06-20 17:54:48 +0530 IST
	 CPU (min|max|avg) seconds:     0.0005 |     0.0016 |     0.0009
	 MEM (min|max|avg) Mib    :    20.7266 |    21.2734 |    21.0947
--------------------------------------------------------------------------------


-------------------------------------------

Usage report: 40 pods in namespace openshift-storage using 40 PVCs with Storage Class <odf-lvm-vg1>
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Pod lvm-operator-controller-manager-959d89f47-9mbvd between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0025 |     0.0093 |     0.0055
	 MEM (min|max|avg) Mib    :    55.2617 |    58.6016 |    56.5464
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container kube-rbac-proxy between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0007 |     0.0002
	 MEM (min|max|avg) Mib    :     9.7031 |     9.7031 |     9.7031
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container manager between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0025 |     0.0077 |     0.0048
	 MEM (min|max|avg) Mib    :    26.6406 |    27.9570 |    27.4265
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container metricsexporter between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0021 |     0.0006
	 MEM (min|max|avg) Mib    :    18.5703 |    21.2734 |    19.4167
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Pod topolvm-controller-cf7f49c87-jzw7c between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0057 |     0.0567 |     0.0220
	 MEM (min|max|avg) Mib    :   114.2461 |   121.3867 |   117.8356
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-resizer between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0072 |     0.0021
	 MEM (min|max|avg) Mib    :    25.4414 |    28.4453 |    26.6300
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-snapshotter between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0008 |     0.0003
	 MEM (min|max|avg) Mib    :    12.9648 |    13.0469 |    12.9968
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container liveness-probe between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0010 |     0.0003
	 MEM (min|max|avg) Mib    :    10.8867 |    11.1797 |    11.0144
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container topolvm-controller between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0028 |     0.0461 |     0.0115
	 MEM (min|max|avg) Mib    :    35.9258 |    37.4180 |    36.4629
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-provisioner between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0014 |     0.0265 |     0.0078
	 MEM (min|max|avg) Mib    :    28.8047 |    32.9297 |    30.7315
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Pod topolvm-node-4pslc between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0019 |     0.2095 |     0.1342
	 MEM (min|max|avg) Mib    :    95.5352 |   134.3164 |   111.2110
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container topolvm-node between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0010 |     0.0372 |     0.0116
	 MEM (min|max|avg) Mib    :    44.0742 |    55.6211 |    48.2161
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container csi-registrar between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0005 |     0.0001
	 MEM (min|max|avg) Mib    :     6.8750 |     6.9609 |     6.8969
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container liveness-probe between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0012 |     0.0002
	 MEM (min|max|avg) Mib    :     8.9062 |     9.2148 |     9.0326
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container lvmd between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.1948 |     0.1222
	 MEM (min|max|avg) Mib    :    33.1133 |    67.4180 |    47.0654
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Pod vg-manager-jhd8k between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0020 |     0.0008
	 MEM (min|max|avg) Mib    :    21.3008 |    21.6484 |    21.5485
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Container vg-manager between 2022-06-20 17:57:15 +0530 IST and 2022-06-20 18:07:00 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0020 |     0.0008
	 MEM (min|max|avg) Mib    :    21.3008 |    21.6484 |    21.5485
--------------------------------------------------------------------------------

------------------------------------

Usage report: 45 pods in namespace openshift-storage using 45 PVCs with Storage Class <odf-lvm-vg4>
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Pod lvm-operator-controller-manager-74f564cd98-tk969 between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0026 |     0.0087 |     0.0053
	 MEM (min|max|avg) Mib    :    47.7812 |    53.7305 |    51.8880
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container kube-rbac-proxy between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :    13.2188 |    13.2188 |    13.2188
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container manager between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0023 |     0.0078 |     0.0045
	 MEM (min|max|avg) Mib    :    23.4102 |    24.5430 |    24.0906
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container metricsexporter between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0033 |     0.0006
	 MEM (min|max|avg) Mib    :    10.8398 |    15.9727 |    14.5787
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Pod topolvm-controller-65489bfd78-qcwkr between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0022 |     0.0586 |     0.0206
	 MEM (min|max|avg) Mib    :   104.4688 |   122.5000 |   118.6119
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-snapshotter between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0008 |     0.0002
	 MEM (min|max|avg) Mib    :    12.8086 |    12.9453 |    12.8869
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container liveness-probe between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0008 |     0.0002
	 MEM (min|max|avg) Mib    :     8.3750 |     9.1562 |     8.6872
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container topolvm-controller between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0270 |     0.0102
	 MEM (min|max|avg) Mib    :    35.8281 |    40.7188 |    38.2821
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-provisioner between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0310 |     0.0078
	 MEM (min|max|avg) Mib    :    22.4102 |    33.3125 |    31.8017
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-resizer between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0068 |     0.0022
	 MEM (min|max|avg) Mib    :    25.0469 |    28.6055 |    26.9541
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Pod topolvm-node-5jb5m between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0019 |     0.2135 |     0.1280
	 MEM (min|max|avg) Mib    :    68.3906 |   127.5664 |   100.0111
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container liveness-probe between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0005 |     0.0002
	 MEM (min|max|avg) Mib    :     8.4023 |     8.6953 |     8.5797
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container lvmd between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.1977 |     0.1164
	 MEM (min|max|avg) Mib    :    18.6875 |    53.2031 |    38.3720
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container topolvm-node between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0009 |     0.0291 |     0.0113
	 MEM (min|max|avg) Mib    :    31.9258 |    56.3477 |    43.7996
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container csi-registrar between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0006 |     0.0001
	 MEM (min|max|avg) Mib    :     9.1641 |     9.3516 |     9.2598
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Pod vg-manager-6jlq9 between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0020 |     0.0009
	 MEM (min|max|avg) Mib    :    22.3828 |    22.8438 |    22.6244
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Container vg-manager between 2022-06-21 12:11:45 +0530 IST and 2022-06-21 12:23:34 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0020 |     0.0009
	 MEM (min|max|avg) Mib    :    22.3828 |    22.8438 |    22.6244
-------------------------------------------------------------------------------

-------------------------------
Usage report: 50 pods in namespace openshift-storage using 50 PVCs with Storage Class <odf-lvm-vg4>
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Pod lvm-operator-controller-manager-74f564cd98-tk969 between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0025 |     0.0088 |     0.0055
	 MEM (min|max|avg) Mib    :    52.2070 |    56.7383 |    54.3104
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container manager between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0024 |     0.0075 |     0.0045
	 MEM (min|max|avg) Mib    :    23.5039 |    24.9023 |    24.4938
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container metricsexporter between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0035 |     0.0007
	 MEM (min|max|avg) Mib    :    14.8125 |    18.8828 |    16.5509
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for lvm-operator-controller-manager deployment's Container kube-rbac-proxy between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0009 |     0.0002
	 MEM (min|max|avg) Mib    :    13.2656 |    13.2656 |    13.2656
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Pod topolvm-controller-65489bfd78-qcwkr between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0056 |     0.0507 |     0.0179
	 MEM (min|max|avg) Mib    :   119.2227 |   128.8984 |   126.3712
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-provisioner between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0009 |     0.0345 |     0.0065
	 MEM (min|max|avg) Mib    :    31.8789 |    38.2969 |    35.6588
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-resizer between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0093 |     0.0018
	 MEM (min|max|avg) Mib    :    25.5039 |    28.5781 |    27.4727
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container csi-snapshotter between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0001 |     0.0009 |     0.0003
	 MEM (min|max|avg) Mib    :    13.1055 |    13.2070 |    13.1620
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container liveness-probe between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0008 |     0.0002
	 MEM (min|max|avg) Mib    :     8.6094 |     9.4883 |     8.8126
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-controller deployment's Container topolvm-controller between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0029 |     0.0271 |     0.0092
	 MEM (min|max|avg) Mib    :    39.6953 |    43.6680 |    41.2651
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Pod topolvm-node-5jb5m between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0019 |     0.2090 |     0.1030
	 MEM (min|max|avg) Mib    :   100.8945 |   137.1836 |   120.3202
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container csi-registrar between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0005 |     0.0001
	 MEM (min|max|avg) Mib    :     9.3086 |     9.4375 |     9.3757
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container liveness-probe between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.0008 |     0.0002
	 MEM (min|max|avg) Mib    :     8.8672 |     9.2617 |     9.0496
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container lvmd between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0000 |     0.1910 |     0.0933
	 MEM (min|max|avg) Mib    :    31.9258 |    62.1250 |    47.2663
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for topolvm-node daemonset's Container topolvm-node between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0010 |     0.0212 |     0.0094
	 MEM (min|max|avg) Mib    :    50.7227 |    59.3789 |    54.6286
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Pod vg-manager-6jlq9 between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0020 |     0.0009
	 MEM (min|max|avg) Mib    :    22.6367 |    23.5000 |    23.0965
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Report for vg-manager daemonset's Container vg-manager between 2022-06-21 12:35:20 +0530 IST and 2022-06-21 12:52:12 +0530 IST
	 CPU (min|max|avg) seconds:     0.0003 |     0.0020 |     0.0009
	 MEM (min|max|avg) Mib    :    22.6367 |    23.5000 |    23.0965
--------------------------------------------------------------------------------

```


Signed-off-by: Santosh Pillai <sapillai@redhat.com>