### PR TITLE
fix: renamed service account

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -256,7 +256,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: controller-manager
+        serviceAccountName: lvm-controller-manager
       deployments:
       - label:
           app.kubernetes.io/name: lvm-operator
@@ -276,6 +276,18 @@ spec:
                 exporter: lvm-operator
             spec:
               containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -326,18 +338,6 @@ spec:
                     memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources: {}
               - command:
                 - /metricsexporter
                 image: quay.io/ocs-dev/lvm-operator:latest
@@ -351,7 +351,7 @@ spec:
                     memory: 30Mi
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: controller-manager
+              serviceAccountName: lvm-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -386,7 +386,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: controller-manager
+        serviceAccountName: lvm-controller-manager
     strategy: deployment
   installModes:
   - supported: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,5 +77,5 @@ spec:
           requests:
             cpu: 30m
             memory: 30Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: lvm-controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: lvm-controller-manager
   namespace: system

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: lvm-controller-manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: lvm-controller-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: lvm-controller-manager
   namespace: system


### PR DESCRIPTION
changed service account name from default controller-manager to
lvm-controller-manager to distinguish it with various other operators
installed in same namespace.

Output from terminal:
[riyasinghal@fedora lvm-operator]$ oc get sa -n openshift-storage
NAME SECRETS AGE
builder 2 3m36s
default 2 3m36s
deployer 2 3m36s
lvm-catalogsource 2 3m36s
lvm-controller-manager 2 2m34s
topolvm-controller 2 2m37s
topolvm-node 2 2m35s
vg-manager 2 2m39s

Signed-off-by: riya-singhal31 <rsinghal@redhat.com>