### PR TITLE
Fix panic when checking the snapshot status in the e2e tests

### DIFF
--- a/e2e/pvc_check.go
+++ b/e2e/pvc_check.go
@@ -79,7 +79,10 @@ func pvcTest() {
 				By("Verifying that the Snapshot is ready")
 				Eventually(func() bool {
 					err := crClient.Get(ctx, types.NamespacedName{Name: snapshot.Name, Namespace: snapshot.Namespace}, snapshot)
-					return err == nil && *snapshot.Status.ReadyToUse
+					if err == nil && snapshot.Status.ReadyToUse != nil {
+						return *snapshot.Status.ReadyToUse
+					}
+					return false
 				}, timeout, interval).Should(BeTrue())
 
 				By("Creating a clone of the filesystem pvc")
@@ -182,7 +185,10 @@ func pvcTest() {
 				By("Verifying that the Snapshot is ready")
 				Eventually(func() bool {
 					err := crClient.Get(ctx, types.NamespacedName{Name: snapshot.Name, Namespace: snapshot.Namespace}, snapshot)
-					return err == nil && *snapshot.Status.ReadyToUse
+					if err == nil && snapshot.Status.ReadyToUse != nil {
+						return *snapshot.Status.ReadyToUse
+					}
+					return false
 				}, timeout, interval).Should(BeTrue())
 
 				By("Creating a clone of the block-pvc")

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	timeout                   = time.Minute * 15
-	interval                  = time.Second * 30
+	interval                  = time.Second * 10
 	lvmVolumeGroupName        = "vg1"
 	storageClassName          = "odf-lvm-vg1"
 	volumeSnapshotClassName   = "odf-lvm-vg1"


### PR DESCRIPTION
This commit checks if the Snapshot.Status.ReadyToUse field is not nil before attempting to access it.