### PR TITLE
fix: updates codespell options

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -20,4 +20,5 @@ jobs:
           exclude_file: go.sum
           check_filenames: true
           check_hidden: true
-          skip: vendor
+          skip: ./vendor,./LICENSE
+          ignore_words_list: ro


### PR DESCRIPTION
Codespell recently started tagging valid words as errors.
This commit adds files and words to those to be excluded/ignored
in order to get around the problem.

Signed-off-by: N Balachandran <nibalach@redhat.com>