### PR TITLE
refactor: move function to different file

### DIFF
--- a/pkg/vgmanager/filter.go
+++ b/pkg/vgmanager/filter.go
@@ -33,45 +33,6 @@ const (
 	usableDeviceType      = "usableDeviceType"
 )
 
-// filterAvailableDevices returns:
-// validDevices: the list of blockdevices considered available
-// delayedDevices: the list of blockdevices considered available, but first observed less than 'minDeviceAge' time ago
-// error
-func (r *VGReconciler) filterAvailableDevices(blockDevices []internal.BlockDevice) ([]internal.BlockDevice, []internal.BlockDevice, error) {
-	var availableDevices, delayedDevices []internal.BlockDevice
-	// using a label so `continue DeviceLoop` can be used to skip devices
-DeviceLoop:
-	for _, blockDevice := range blockDevices {
-
-		// store device in deviceAgeMap
-		r.deviceAgeMap.storeDeviceAge(blockDevice.KName)
-
-		devLogger := r.Log.WithValues("Device.Name", blockDevice.Name)
-		for name, filter := range FilterMap {
-			var valid bool
-			var err error
-			filterLogger := devLogger.WithValues("filter.Name", name)
-			valid, err = filter(blockDevice, r.executor)
-			if err != nil {
-				filterLogger.Error(err, "filter error")
-				valid = false
-				continue DeviceLoop
-			} else if !valid {
-				filterLogger.Info("does not match filter")
-				continue DeviceLoop
-			}
-		}
-		// check if the device is older than deviceMinAge
-		isOldEnough := r.deviceAgeMap.isOlderThan(blockDevice.KName)
-		if isOldEnough {
-			availableDevices = append(availableDevices, blockDevice)
-		} else {
-			delayedDevices = append(delayedDevices, blockDevice)
-		}
-	}
-	return availableDevices, delayedDevices, nil
-}
-
 // maps of function identifier (for logs) to filter function.
 // These are passed the localv1alpha1.DeviceInclusionSpec to make testing easier,
 // but they aren't expected to use it


### PR DESCRIPTION
Moved the filterAvailableDevices function to the
vgmanager_controller.go function. The filter.go will
have only the filter map and functions.

Signed-off-by: N Balachandran <nibalach@redhat.com>