### PR TITLE
fix: set the thinpool chunksize to 128KiB

### DIFF
--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	ControllerName   = "vg-manager"
-	DefaultChunkSize = "512"
+	DefaultChunkSize = "128"
 )
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Based on feedback and performance tests, the chunksize for the lvm thinpool is being reduced to 128KiB.

Signed-off-by: N Balachandran <nibalach@redhat.com>