### PR TITLE
fix: allow all kind of paths

### DIFF
--- a/pkg/internal/block_device.go
+++ b/pkg/internal/block_device.go
@@ -62,9 +62,8 @@ type BlockDevice struct {
 	Serial     string        `json:"serial,omitempty"`
 	PartLabel  string        `json:"partLabel,omitempty"`
 
-	// DiskByPath is not part of lsblk output
-	// fetch and set it only if specified in the CR
-	DiskByPath string
+	// DevicePath is the path given by user
+	DevicePath string
 }
 
 // ListBlockDevices using the lsblk command


### PR DESCRIPTION
Earlier we were supporting only `/dev/disk/by-path/` and `dev` kind of paths. With the current approach we will support all kind of paths.

The status will show the names only now onwards.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>