### PR TITLE
fix: do not verify lvmcluster from controller anymore

### DIFF
--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -25,11 +25,6 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-const (
-	// ConditionLVMClusterValid communicates if LVMCluster CR is invalid
-	ConditionLVMClusterValid conditionsv1.ConditionType = "LVMClusterValid"
-)
-
 // LVMClusterSpec defines the desired state of LVMCluster
 type LVMClusterSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -15,21 +15,3 @@ limitations under the License.
 */
 
 package controllers
-
-import (
-	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-	corev1 "k8s.io/api/core/v1"
-
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
-)
-
-func setLVMClusterCRvalidCondition(conditions *[]conditionsv1.Condition,
-	status corev1.ConditionStatus, reason string, message string) {
-
-	conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
-		Type:    lvmv1alpha1.ConditionLVMClusterValid,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
-	})
-}

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -116,12 +116,6 @@ func (r *LVMClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	err = r.verifyLvmClusterSpec(ctx, lvmCluster)
-	if err != nil {
-		r.Log.Error(err, "failed to verify LVMCluster")
-		return ctrl.Result{}, err
-	}
-
 	err = r.checkIfOpenshift(ctx)
 	if err != nil {
 		r.Log.Error(err, "failed to check cluster type")
@@ -225,71 +219,6 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 	r.Log.Info("successfully reconciled LvmCluster")
 
 	return ctrl.Result{}, nil
-}
-
-func (r *LVMClusterReconciler) verifyLvmClusterSpec(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {
-
-	err := r.verifyLvmClusterDeviceClasses(ctx, instance)
-	if err != nil {
-		// Apply status changes
-		updateErr := r.Client.Status().Update(ctx, instance)
-		if updateErr != nil {
-			r.Log.Error(updateErr, "failed to update LVMCluster status")
-			return updateErr
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (r *LVMClusterReconciler) verifyLvmClusterDeviceClasses(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {
-
-	// make sure no device overlap with another VGs
-	// use map to find the duplicate entries for paths
-	/*
-		{
-		  "nodeSelector1": {
-		        "/dev/sda": "vg1",
-		        "/dev/sdb": "vg1"
-		    },
-		    "nodeSelector2": {
-		        "/dev/sda": "vg1",
-		        "/dev/sdb": "vg1"
-		    }
-		}
-	*/
-	devices := make(map[string]map[string]string)
-
-	for _, deviceClass := range instance.Spec.Storage.DeviceClasses {
-		if deviceClass.DeviceSelector != nil {
-			nodeSelector := deviceClass.NodeSelector.String()
-			for _, path := range deviceClass.DeviceSelector.Paths {
-				if val, ok := devices[nodeSelector][path]; ok {
-					var err error
-					if val != deviceClass.Name {
-						err = fmt.Errorf("Error: device path %s overlaps in two different deviceClasss %s and %s", path, val, deviceClass.Name)
-					} else {
-						err = fmt.Errorf("Error: device path %s is specified at multiple places in deviceClass %s", path, val)
-					}
-					r.Log.Error(err, "failed to verify device paths")
-
-					setLVMClusterCRvalidCondition(&instance.Status.Conditions, corev1.ConditionFalse, "CRInvalid", err.Error())
-					return err
-				}
-
-				if devices[nodeSelector] == nil {
-					devices[nodeSelector] = make(map[string]string)
-				}
-
-				devices[nodeSelector][path] = deviceClass.Name
-			}
-		}
-	}
-
-	setLVMClusterCRvalidCondition(&instance.Status.Conditions, corev1.ConditionTrue, "CRValid", "LVMCluster CR is validated successfully")
-
-	return nil
 }
 
 func (r *LVMClusterReconciler) updateLVMClusterStatus(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {


### PR DESCRIPTION
The responsibility of CR verification moved to the validation webhook.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>