### PR TITLE
build: add labels in the csv

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -59,6 +59,10 @@ metadata:
       "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/red-hat-storage/lvm-operator
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: lvm-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -33,6 +33,10 @@ metadata:
     repository: https://github.com/red-hat-storage/lvm-operator
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.cybozu.com", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: @BUNDLE_PACKAGE@.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2118972

full_version label is added in the DS build pipeline if and only if we have some labels defined in the CSV. currently, LVMO CSV does not hold any labels. The PR does add few labels into the CSV.