### PR TITLE
fix: deletion of lvmcluster which includes wrong paths

### DIFF
--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -324,6 +324,12 @@ func (r *VGReconciler) processDelete(ctx context.Context, volumeGroup *lvmv1alph
 	}
 	if lvmdConfig == nil {
 		r.Log.Info("lvmd config file does not exist")
+		// Remove the VG entry in the lvmvolumegroupnodestatus that was added to indicate the failures to the user.
+		// This allows the lvmcluster to get deleted and not stuck/wait forever as lvmcluster looks for the lvmvolumegroupnodestatus before deleting.
+		if statuserr := r.updateStatus(ctx, nil); statuserr != nil {
+			r.Log.Error(statuserr, "failed to update status", "VGName", volumeGroup.Name)
+			return statuserr
+		}
 		return nil
 	}
 	// To avoid having to iterate through device classes multiple times, map from name to config index


### PR DESCRIPTION
Deleting the lvmvolumegroup CR does not clean the VG entry in the
lvmvolumegroupnodestatus if lvmdconfig file does not exists and returns
immediately. Fix the same via updating the lvmvolumegroupnodestatus.

Signed-off-by: riya-singhal31 <rsinghal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2124202