### PR TITLE
fix: fixes deploy-with-olm on ocp 4.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.26.2/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/olm-deploy/openshift-storage-namespace.yaml
+++ b/olm-deploy/openshift-storage-namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: openshift-storage
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: "privileged"


### PR DESCRIPTION
This fixes the following:
- Added the podsecurity labels to the openshift-storage namespace yaml.
- Upgraded to opm v1.26.2 to fix a permission issue with accessing the sqlite db in te catalog.

Signed-off-by: N Balachandran <nibalach@redhat.com>