### PR TITLE
Bug 2133742: fix: fixes e2e tests for release-4.11

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -20,4 +20,5 @@ jobs:
           exclude_file: go.sum
           check_filenames: true
           check_hidden: true
-          skip: vendor
+          skip: ./vendor,./LICENSE
+          ignore_words_list: ro

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or
           # v1.2.3 or `latest` to use the latest version
-          version: v1.45.2
+          version: v1.48
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -100,16 +100,6 @@ func ValidateTopolvmNode() error {
 	}, timeout, interval).Should(BeTrue())
 	debug("TopoLVM node daemonset found\n")
 
-	// checking for the ready status
-	Eventually(func() bool {
-		err := DeployManagerObj.GetCrClient().Get(context.TODO(), types.NamespacedName{Name: topolvmNodeDaemonSetName, Namespace: InstallNamespace}, &ds)
-		if err != nil {
-			debug("Error getting TopoLVM node daemonset %s: %s\n", topolvmNodeDaemonSetName, err.Error())
-		}
-		return ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
-	}, timeout, interval).Should(BeTrue())
-	debug("TopoLVM node daemonset : Status is ready\n")
-
 	return nil
 }
 


### PR DESCRIPTION
Removed the check for the topolvm node deployment status in the release-4.11. 
As no disks are added, the topolvm-node pods never become ready.

Signed-off-by: N Balachandran <nibalach@redhat.com>