### PR TITLE
fix: add test ns labels for PSA

### DIFF
--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -34,6 +34,9 @@ func createNamespace(ctx context.Context, namespace string) error {
 	label := make(map[string]string)
 	// label required for monitoring this namespace
 	label["openshift.io/cluster-monitoring"] = "true"
+	label["pod-security.kubernetes.io/enforce"] = "privileged"
+	label["security.openshift.io/scc.podSecurityLabelSync"] = "false"
+
 	ns := &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
@@ -52,6 +55,9 @@ func deleteNamespaceAndWait(ctx context.Context, namespace string) error {
 	label := make(map[string]string)
 	// label required for monitoring this namespace
 	label["openshift.io/cluster-monitoring"] = "true"
+	label["pod-security.kubernetes.io/enforce"] = "baseline"
+	label["security.openshift.io/scc.podSecurityLabelSync"] = "false"
+
 	ns := &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,

--- a/e2e/lvmcluster.go
+++ b/e2e/lvmcluster.go
@@ -30,7 +30,7 @@ import (
 func generateLVMCluster() *v1alpha1.LVMCluster {
 	lvmClusterRes := &v1alpha1.LVMCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "lvmcluster-sample",
+			Name:      "odf-lvmcluster",
 			Namespace: installNamespace,
 		},
 		Spec: v1alpha1.LVMClusterSpec{
@@ -40,8 +40,8 @@ func generateLVMCluster() *v1alpha1.LVMCluster {
 						Name: "vg1",
 						ThinPoolConfig: &v1alpha1.ThinPoolConfig{
 							Name:               "mytp1",
-							SizePercent:        50,
-							OverprovisionRatio: 50,
+							SizePercent:        90,
+							OverprovisionRatio: 5,
 						},
 					},
 				},


### PR DESCRIPTION
The PSA changes in OCP 4.12 prevent pods from starting as ns are labeled restricted by default. This commit sets the label pod-security.kubernetes.io/enforce: "baseline"
on the lvm-endtoendtest to allow the test pods to run. This also renames a file to conform to the naming convention.

Signed-off-by: N Balachandran <nibalach@redhat.com>