### PR TITLE
fix: add missing ns labels for make deploy

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,11 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: lvm-operator
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The namespace created by make deploy was missing the PSA labels, preventing the topolvm-node and vg-manager pods from starting on OCP 4.12. This commit adds them and the missing cluster monitoring label.

Signed-off-by: N Balachandran <nibalach@redhat.com>