### PR TITLE
chore: update the weekly build github action

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -1,34 +1,31 @@
-name: Manual Operator Build Dispatch
+name: manual-operator-build-push
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to Build From'
+        description: 'Branch to build from'
         required: true
-      tag:
-        description: 'Additional tag for the build (such as alpha, beta, etc.) - Optional'
-        default: ''
-env:
-  GO_VERSION: "1.18"
-  IMG: "quay.io/lvmo/lvm-operator"
 
 jobs:
   build-and-publish-image:
     name: Build and publish the LVMO image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
           ref: ${{ github.event.inputs.branch }}
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
 
       # 'test' is a sub-target of 'docker-build' and so cache go build & mod
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
       - name: Go Build Cache
         uses: actions/cache@v2
         with:
@@ -45,21 +42,40 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_LVMO_ROBOT_NAME_2 }}
-          password: ${{ secrets.QUAY_LVMO_ROBOT_TOKEN_2 }}
+          username: ${{ secrets.QUAY_LVMO_ROBOT_NAME }}
+          password: ${{ secrets.QUAY_LVMO_ROBOT_TOKEN }}
 
       - name: Get Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Prepare image tag
         id: prep
         run: |
-          LVMO_OPERATOR_IMAGE=${{env.IMG}}:${{ github.event.inputs.branch }}-${{ steps.date.outputs.date }}
-          echo ::set-output name=operator-img::${LVMO_OPERATOR_IMAGE}
+          TAG=${{ github.event.inputs.branch }}-${{ steps.date.outputs.date }}
+          OPERATOR_IMG=quay.io/lvmo/lvm-operator:${TAG}
+          OPERATOR_IMG_LATEST="quay.io/lvmo/lvm-operator:latest"
+          OPERATOR_BUNDLE_IMG="quay.io/lvmo/lvm-operator-bundle:${TAG}"
+          OPERATOR_BUNDLE_IMG_LATEST="quay.io/lvmo/lvm-operator-bundle:latest"
+          echo "op-latest=${OPERATOR_IMG_LATEST}" >> $GITHUB_OUTPUT
+          echo "bundle-latest=${OPERATOR_BUNDLE_IMG_LATEST}" >> $GITHUB_OUTPUT
+          echo "op-img=${OPERATOR_IMG}" >> $GITHUB_OUTPUT
+          echo "bundle-img=${OPERATOR_BUNDLE_IMG}" >> $GITHUB_OUTPUT
 
-      - name: Build operator docker image
-        run: make docker-build-combined IMG=${{steps.prep.outputs.operator-img}}
+      - name: Build and publish operator image
+        env:
+          IMG: ${{ steps.prep.outputs.op-img }}
+        run: |
+          make docker-build-combined
+          make docker-push
+          docker tag ${{ steps.prep.outputs.op-img }} ${{ steps.prep.outputs.op-latest }}
+          docker push ${{ steps.prep.outputs.op-latest }}
 
-      - name: Publish operator image
-        run: make docker-push IMG=${{steps.prep.outputs.operator-img}}
+      - name: Build and publish operator bundle image
+        env:
+          BUNDLE_IMG: ${{ steps.prep.outputs.bundle-img }}
+        run: |
+          make bundle bundle-build
+          make bundle-push
+          docker tag ${{ steps.prep.outputs.bundle-img }} ${{ steps.prep.outputs.bundle-latest }}
+          docker push ${{ steps.prep.outputs.bundle-latest }}

--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -1,51 +1,18 @@
-name: LVMO Weekly Image Publish
+name: weekly-image-build
 
 # Runs every Monday at 23:00 UTC
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * 1"
-env:
-  GO_VERSION: "1.18"
-  IMG: "quay.io/ocs-dev/lvm-operator:weekly"
 
 jobs:
-  build-and-publish-image:
-    name: Build and publish the LVMO image
+  publish-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - name: invoke-operator-build
+        uses: benc-uk/workflow-dispatch@v1
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      # 'test' is a sub-target of 'docker-build' and so cache go build & mod
-      - id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-      - name: Go Build Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-
-      - name: Login to quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_LVMO_ROBOT_NAME }}
-          password: ${{ secrets.QUAY_LVMO_ROBOT_TOKEN }}
-
-      - name: Build operator docker image
-        run: make docker-build-combined IMG=${{env.IMG}}
-
-      - name: Publish operator image
-        run: make docker-push IMG=${{env.IMG}}
+          workflow: manual-operator-build-push
+          repo: red-hat-storage/lvm-operator
+          inputs: '{ "branch": "main" }'


### PR DESCRIPTION
Updates the weekly build github action to call a second workflow. This will allow us to trigger a build for red-hat-storage/topolvm as part of the weekly build.

Signed-off-by: N Balachandran <nibalach@redhat.com>