### PR TITLE
doc: add an upgrade doc

### DIFF
--- a/doc/user-guide/upgrade.md
+++ b/doc/user-guide/upgrade.md
@@ -1,0 +1,4 @@
+## Upgrading LVMO
+
+Upgrades from release-4.11 to a later version are not supported due to a breaking change in the TopoLVM CSI driver.
+Please see the documentation [here](https://github.com/topolvm/topolvm/blob/main/docs/proposals/rename-group.md) for more details.


### PR DESCRIPTION
Specify that upgrades from release 4.11 to a higher version are not supported due to a breaking change in TopoLVM.

Signed-off-by: N Balachandran <nibalach@redhat.com>