### PR TITLE
fix: run weekly-build action only on the main repo instead of forks

### DIFF
--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
+    if: >
+      github.repository == 'red-hat-storage/lvm-operator' &&
+      github.ref == 'refs/heads/main'
     steps:
       - name: invoke-operator-build
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>